### PR TITLE
Add basic plotting macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,19 +11,19 @@ project(${MODULE_NAME})
 
 # Install directories
 SET(INSTALL_BIN_DIR ${CMAKE_INSTALL_PREFIX}/bin)
+SET(INSTALL_MACRO_DIR ${CMAKE_INSTALL_PREFIX}/macro)
 SET(INSTALL_INC_DIR ${CMAKE_INSTALL_PREFIX}/include/${MODULE_NAME})
 SET(INSTALL_LIB_DIR ${CMAKE_INSTALL_PREFIX}/lib)
 
 # Source directories
 SET(IMP_SRC_DIR ${CMAKE_SOURCE_DIR}/src)
 SET(INC_SRC_DIR ${CMAKE_SOURCE_DIR}/include/${MODULE_NAME})
+SET(MACRO_SRC_DIR ${CMAKE_SOURCE_DIR}/macro)
 
 # Library name
 SET(LIBRARY_NAME ${MODULE_NAME})
 # Executable name
 SET(EXECUTABLE_NAME mcStepAnalysis)
-
-
 
 # Required source files to build the library.
 set(SRCS
@@ -55,6 +55,11 @@ include_directories(include/)
 set(EXE_SRCS
     ${IMP_SRC_DIR}/analyseMCSteps.cxx
    )
+
+# Macros to be copied
+set(MACROS
+   ${MACRO_SRC_DIR}/plotAnalysisHistograms.C
+  )
 
 ########
 # ROOT #
@@ -104,3 +109,5 @@ install(TARGETS ${MODULE_NAME} DESTINATION ${INSTALL_LIB_DIR})
 install(FILES ${ROOT_DICT_LIB_FILES} DESTINATION ${INSTALL_LIB_DIR})
 # Install executables
 install(TARGETS ${EXECUTABLE_NAME} DESTINATION ${INSTALL_BIN_DIR})
+# Install macros
+install(FILES ${MACROS} DESTINATION ${INSTALL_MACRO_DIR})

--- a/include/MCStepLogger/MCAnalysisFileWrapper.h
+++ b/include/MCStepLogger/MCAnalysisFileWrapper.h
@@ -60,6 +60,16 @@ class MCAnalysisFileWrapper
   {
     return *castHistogram<T>(findHistogram(name), false);
   }
+  /// get histogram at position
+  template <typename T = TH1>
+  T& getHistogram(int position)
+  {
+    if (position < 0 || position >= mHistograms.size()) {
+      std::cerr << "FATAL: Histogram at invalid position " << position << " requested.\n";
+      exit(1);
+    }
+    return *castHistogram<T>(mHistograms[position].get(), false);
+  }
   /// get a 1D histogram and directly register it to this this wrapper
   template <typename T>
   T& getHistogram(const std::string& name, int nBins, double lower, double upper)
@@ -110,6 +120,8 @@ class MCAnalysisFileWrapper
   //
   /// getting the meta info of the analysis run
   MCAnalysisMetaInfo& getAnalysisMetaInfo();
+  /// get number of histograms
+  int nHistograms() const;
   //
   // verbosity
   //

--- a/macro/plotAnalysisHistograms.C
+++ b/macro/plotAnalysisHistograms.C
@@ -1,0 +1,69 @@
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include <iostream>
+#include <vector>
+#include <string>
+
+#include "TH1D.h"
+#include "TCanvas.h"
+#include "TLegend.h"
+#include "TStyle.h"
+
+#include <MCStepLogger/MCAnalysisFileWrapper.h>
+#include <MCStepLogger/MetaInfo.h>
+#endif
+
+// Produce overlay histograms for some observables and pass to canvases
+void plotHistograms(const char* analysisFilepath, const char* outputDir = "./")
+{
+  o2::mcstepanalysis::MCAnalysisFileWrapper wrapper;
+  wrapper.read(analysisFilepath);
+
+  for (int i = 0; i < wrapper.nHistograms(); i++) {
+    TH1& histo = wrapper.getHistogram(i);
+    TCanvas* canvas = new TCanvas(histo.GetName(), "", 600, 500);
+    TLegend* legend = new TLegend(0.1, 0.7, 0.3, 0.9);
+
+    histo.Draw("hist");
+    legend->AddEntry(&histo, wrapper.getAnalysisMetaInfo().label.c_str());
+    legend->Draw("same");
+
+    std::string outputDirStr(outputDir);
+    if (outputDirStr.back() != '/') {
+      outputDirStr += '/';
+    }
+
+    canvas->SaveAs(std::string(outputDirStr + histo.GetName() + ".eps").c_str());
+    canvas->SaveAs(std::string(outputDirStr + histo.GetName() + ".png").c_str());
+    delete canvas;
+  }
+}
+
+// Produce overlay histograms for some observables and pass to canvases
+void plotHistogram(const char* analysisFilepath, const char* histoName,
+                   const char* outputDir = "./")
+{
+  o2::mcstepanalysis::MCAnalysisFileWrapper wrapper;
+  wrapper.read(analysisFilepath);
+
+  if (!wrapper.hasHistogram(histoName)) {
+    std::cerr << "Histogram " << histoName << " does not exist.\n";
+    return;
+  }
+
+  TH1& histo = wrapper.getHistogram(histoName);
+  TCanvas* canvas = new TCanvas(histo.GetName(), "", 600, 500);
+  TLegend* legend = new TLegend(0.1, 0.7, 0.3, 0.9);
+
+  histo.Draw("hist");
+  legend->AddEntry(&histo, wrapper.getAnalysisMetaInfo().label.c_str());
+  legend->Draw("same");
+
+  std::string outputDirStr(outputDir);
+  if (outputDirStr.back() != '/') {
+    outputDirStr += '/';
+  }
+
+  canvas->SaveAs(std::string(outputDirStr + histoName + ".eps").c_str());
+  canvas->SaveAs(std::string(outputDirStr + histoName + ".png").c_str());
+  delete canvas;
+}

--- a/src/MCAnalysisFileWrapper.cxx
+++ b/src/MCAnalysisFileWrapper.cxx
@@ -112,10 +112,14 @@ bool MCAnalysisFileWrapper::createDirectory(const std::string& dir)
   return (gSystem->AccessPathName(dir.c_str()) == 0);
 }
 
-/// getting the meta info of the analysis run
 MCAnalysisMetaInfo& MCAnalysisFileWrapper::getAnalysisMetaInfo()
 {
   return mAnalysisMetaInfo;
+}
+
+int MCAnalysisFileWrapper::nHistograms() const
+{
+  return mHistograms.size();
 }
 
 void MCAnalysisFileWrapper::printAnalysisMetaInfo() const


### PR DESCRIPTION
Plotting macro provides two functions to plot either all histograms
contained in an analysis file or a specific one chosen by its name. It
can be used as a baseline to start from to create also pretty plots.