### PR TITLE
Monitor traversed volumes and modules

### DIFF
--- a/include/MCStepLogger/SimpleStepAnalysis.h
+++ b/include/MCStepLogger/SimpleStepAnalysis.h
@@ -83,11 +83,20 @@ class SimpleStepAnalysis : public MCAnalysis
   // steps in the x-y plane
   TH2D* histXY;
 
+  // Module/volume traversed before entering another one
+  TH1I* histTraversedBeforePerMod;
+  TH1I* histTraversedBeforePerVol;
+
+  // Traversed volume/module vs. origin
+  TH2D* histTraversedBeforeVsOriginPerMod;
+  TH2D* histTraversedBeforeVsOriginPerVol;
+  //TH2D* histTraversedBeforeVsOriginPerVol;
+
   // keep steps (under cutting for instance)
   TTree *steptree;
   TFile *stepfile;
-  
-  // pointing to a user cut function 
+
+  // pointing to a user cut function
   cut_function_type* mUserCutFunction = nullptr; //!
 
   ClassDefNV(SimpleStepAnalysis, 1);


### PR DESCRIPTION
Add histograms to monitor in which volume/module a track was before
entering another volume/module. Use these information to extract more
detailed dependencies between volumes/modules and prioritise.