### PR TITLE
[WIP] Modularise and add hit field to StepInfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,16 +19,21 @@ SET(INSTALL_LIB_DIR ${CMAKE_INSTALL_PREFIX}/lib)
 SET(IMP_SRC_DIR ${CMAKE_SOURCE_DIR}/src)
 SET(INC_SRC_DIR ${CMAKE_SOURCE_DIR}/include/${MODULE_NAME})
 SET(MACRO_SRC_DIR ${CMAKE_SOURCE_DIR}/macro)
+SET(PLUGIN_SRC_DIR ${CMAKE_SOURCE_DIR}/plugins)
 
 # Library name
 SET(LIBRARY_NAME ${MODULE_NAME})
 # Executable name
 SET(EXECUTABLE_NAME mcStepAnalysis)
 
+# Plugins
+set(PLUGINS)
+
 # Required source files to build the library.
 set(SRCS
     ${IMP_SRC_DIR}/MCStepInterceptor.cxx
     ${IMP_SRC_DIR}/MCStepLoggerImpl.cxx
+    ${IMP_SRC_DIR}/StepLoggerUtilities.cxx
     ${IMP_SRC_DIR}/StepInfo.cxx
     ${IMP_SRC_DIR}/MCAnalysis.cxx
     ${IMP_SRC_DIR}/BasicMCAnalysis.cxx
@@ -42,6 +47,9 @@ set(SRCS
 # Requried headers to build the library.
 set(HEADERS
    ${INC_SRC_DIR}/StepInfo.h
+   ${INC_SRC_DIR}/StepLogger.h
+   ${INC_SRC_DIR}/FieldLogger.h
+   ${INC_SRC_DIR}/StepLoggerUtilities.h
    ${INC_SRC_DIR}/MetaInfo.h
    ${INC_SRC_DIR}/MCAnalysis.h
    ${INC_SRC_DIR}/BasicMCAnalysis.h
@@ -51,6 +59,23 @@ set(HEADERS
    ${INC_SRC_DIR}/MCAnalysisUtilities.h
    ${INC_SRC_DIR}/ROOTIOUtilities.h
   )
+
+set(ROOT_DICT_HEADERS
+   ${INC_SRC_DIR}/StepInfo.h
+   ${INC_SRC_DIR}/MetaInfo.h
+   ${INC_SRC_DIR}/MCAnalysis.h
+   ${INC_SRC_DIR}/BasicMCAnalysis.h
+   ${INC_SRC_DIR}/SimpleStepAnalysis.h
+   ${INC_SRC_DIR}/MCAnalysisManager.h
+   ${INC_SRC_DIR}/MCAnalysisFileWrapper.h
+   ${INC_SRC_DIR}/MCAnalysisUtilities.h
+   ${INC_SRC_DIR}/ROOTIOUtilities.h
+)
+
+set(O2_HIT_PLUGIN_SRCS
+    ${PLUGIN_SRC_DIR}/O2HitIntercept.cxx
+    )
+
 include_directories(include/)
 
 # Required source for the executable
@@ -85,7 +110,7 @@ include_directories(${Boost_INCLUDE_DIR})
 SET(ROOT_DICT_LINKDEF_FILE ${IMP_SRC_DIR}/MCStepLoggerLinkDef.h)
 SET(ROOT_DICT_NAME "G__${MODULE_NAME}")
 
-ROOT_GENERATE_DICTIONARY(${ROOT_DICT_NAME} ${HEADERS} LINKDEF ${ROOT_DICT_LINKDEF_FILE})
+ROOT_GENERATE_DICTIONARY(${ROOT_DICT_NAME} ${ROOT_DICT_HEADERS} LINKDEF ${ROOT_DICT_LINKDEF_FILE})
 # Files produced by the dictionary generation
 SET(ROOT_DICT_LIB_FILES
     "${PROJECT_BINARY_DIR}/lib${MODULE_NAME}_rdict.pcm"
@@ -95,9 +120,13 @@ SET(ROOT_DICT_LIB_FILES
 # Build a library from the sources specified above together with generated ROOT
 # dictionary
 add_library(${MODULE_NAME} SHARED ${SRCS} "${ROOT_DICT_NAME}.cxx" ${HEADERS})
-
 # Link together with ROOT libs
 target_link_libraries(${MODULE_NAME} -lCore -lHist -lGraf -lGpad -lTree -lVMC -lRIO -lGeom -lEG)
+
+# Plugins
+add_library(O2HitIntercept SHARED ${O2_HIT_PLUGIN_SRCS})
+target_link_libraries(O2HitIntercept ${MODULE_NAME})
+set(PLUGINS ${PLUGINS} O2HitIntercept)
 
 # Add the executable to do analysis with the MCStepLogger output files
 add_executable(${EXECUTABLE_NAME} ${EXE_SRCS})
@@ -106,7 +135,7 @@ target_link_libraries(${EXECUTABLE_NAME} ${MODULE_NAME} ${Boost_LIBRARIES})
 # Install headers
 install(FILES ${HEADERS} DESTINATION ${INSTALL_INC_DIR})
 # Install libraries
-install(TARGETS ${MODULE_NAME} DESTINATION ${INSTALL_LIB_DIR})
+install(TARGETS ${MODULE_NAME} ${PLUGINS} DESTINATION ${INSTALL_LIB_DIR})
 # Install the ROOT dictionary files
 install(FILES ${ROOT_DICT_LIB_FILES} DESTINATION ${INSTALL_LIB_DIR})
 # Install executables

--- a/README.md
+++ b/README.md
@@ -90,6 +90,22 @@ DYLD_INSERT_LIBRARIES=/Users/laurent/alice/sw/osx_x86-64/O2/latest-clion-o2/lib/
 `LD_DEBUG=statistics` must be replaced by `DYLD_PRINT_STATISTICS=1`
 
 
+## Plugins
+
+Together with the standard
+
+```bash
+LD_PRELOAD=path_to/libMCStepLogger.so o2-sim-serial <args>
+```
+
+additional intercepts can be loaded whose sources can be found in [plugins](./plugins). For now, [O2HitIntercept](./plugins/O2HitIntercept.cxx) is used to attach hit information for each step and it is compiled into its own library `libO2HitIntercept.so`. This is done, since hit creation is not a responsibility of `VMC` and hence is separated from the basic step logging.
+
+To use this `O2` specific plugin and attach hit information run
+
+```bash
+LD_PRELOAD="path_to/libMCStepLogger.so path_to/libO2HitIntercept.so" o2-sim-serial <args>
+```
+
 ## MCStepLogAnalysis
 
 Information collected and stored in `MCStepLoggerOutput.root` can be further investigated using the excutable `mcStepAnalysis`. This executable is independent of the simulation itself and produces therefore no overhead when running a simulation. 2 commands are so far available (`analyze`, `checkFile`) including useful help message when typing

--- a/include/MCStepLogger/FieldLogger.h
+++ b/include/MCStepLogger/FieldLogger.h
@@ -1,0 +1,101 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+
+#ifndef FIELDLOGGER_H_
+#define FIELDLOGGER_H_
+
+#include "MCStepLogger/StepInfo.h"
+#include "MCStepLogger/MetaInfo.h"
+#include "MCStepLogger/StepLoggerUtilities.h"
+#include <TBranch.h>
+#include <TClonesArray.h>
+#include <TTree.h>
+#include <TVirtualMC.h>
+#include <TVirtualMCApplication.h>
+#include <iostream>
+
+namespace o2
+{
+
+// a class collecting field access per volume
+class FieldLogger
+{
+  int counter = 0;
+  std::map<int, int> volumetosteps;
+  std::map<int, std::string> idtovolname;
+  bool mTTreeIO = false;
+  std::vector<MagCallInfo> callcontainer;
+
+ public:
+  FieldLogger()
+  {
+    // check if streaming or interactive
+    // configuration done via env variable
+    if (std::getenv("MCSTEPLOG_TTREE")) {
+      mTTreeIO = true;
+    }
+  }
+
+  static FieldLogger& Instance()
+  {
+    static FieldLogger logger;
+    return logger;
+  }
+
+  void addStep(TVirtualMC* mc, const double* x, const double* b)
+  {
+    if (mTTreeIO) {
+      callcontainer.emplace_back(mc, x[0], x[1], x[2], b[0], b[1], b[2]);
+      return;
+    }
+    counter++;
+    int copyNo;
+    auto id = mc->CurrentVolID(copyNo);
+    if (volumetosteps.find(id) == volumetosteps.end()) {
+      volumetosteps.insert(std::pair<int, int>(id, 0));
+    } else {
+      volumetosteps[id]++;
+    }
+    if (idtovolname.find(id) == idtovolname.end()) {
+      idtovolname.insert(std::pair<int, std::string>(id, std::string(mc->CurrentVolName())));
+    }
+  }
+
+  void clear()
+  {
+    counter = 0;
+    volumetosteps.clear();
+    idtovolname.clear();
+    if (mTTreeIO) {
+      callcontainer.clear();
+    }
+  }
+
+  void flush()
+  {
+    if (mTTreeIO) {
+      mcsteploggerutilities::flushToTTree("Calls", &callcontainer);
+    } else {
+      std::cerr << "[FIELDLOGGER]: did " << counter << " steps \n";
+      // summarize steps per volume
+      for (auto& p : volumetosteps) {
+        std::cerr << "[FIELDLOGGER]: VolName " << idtovolname[p.first] << " COUNT " << p.second;
+        std::cerr << "\n";
+      }
+      std::cerr << "[FIELDLOGGER]: ----- END OF EVENT ------\n";
+    }
+    clear();
+  }
+};
+
+} // namespace o2
+
+#endif /* FIELDLOGGER_H_ */

--- a/include/MCStepLogger/SimpleStepAnalysis.h
+++ b/include/MCStepLogger/SimpleStepAnalysis.h
@@ -83,11 +83,20 @@ class SimpleStepAnalysis : public MCAnalysis
   // steps in the x-y plane
   TH2D* histXY;
 
+  // Module/volume traversed before entering another one
+  TH1I* histTraversedBeforePerMod;
+  TH1I* histTraversedBeforePerVol;
+
+  // Traversed volume/module vs. origin
+  TH2D* histTraversedBeforeVsOriginPerMod;
+  TH2D* histTraversedBeforeVsOriginPerVol;
+  //TH2D* histTraversedBeforeVsOriginPerVol;
+
   // keep steps (under cutting for instance)
   TTree *steptree;
   TFile *stepfile;
-  
-  // pointing to a user cut function 
+
+  // pointing to a user cut function
   cut_function_type* mUserCutFunction = nullptr; //!
 
   ClassDefNV(SimpleStepAnalysis, 1);

--- a/include/MCStepLogger/SimpleStepAnalysis.h
+++ b/include/MCStepLogger/SimpleStepAnalysis.h
@@ -54,6 +54,10 @@ class SimpleStepAnalysis : public MCAnalysis
   TH1I* histNStepsPerMod;
   // accumulated number of steps per volume
   TH1I* histNStepsPerVol;
+  // accumulate number of hits per module/region
+  TH1I* histNHitsPerMod;
+  // accumulated number of hits per volume
+  TH1I* histNHitsPerVol;
   // accumulated number of steps per pdg
   TH1I* histNStepsPerPDG;
   TH1I* histNStepsPerVolSorted;

--- a/include/MCStepLogger/StepInfo.h
+++ b/include/MCStepLogger/StepInfo.h
@@ -198,6 +198,7 @@ struct StepInfo {
   bool exited = false;               // if track exited volume during last step
   bool newtrack = false;             // if track is new
   bool insensitiveRegion = false;    // whether step done in sensitive region
+  int detectorHitId = -1;            // Monitor the detector ID in case this step produced a hit
 
   const char* getProdProcessAsString() const;
 

--- a/include/MCStepLogger/StepLogger.h
+++ b/include/MCStepLogger/StepLogger.h
@@ -1,0 +1,194 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+
+#ifndef STEPLOGGER_H_
+#define STEPLOGGER_H_
+
+#include "MCStepLogger/StepInfo.h"
+#include "MCStepLogger/MetaInfo.h"
+#include "MCStepLogger/StepLoggerUtilities.h"
+#include <TBranch.h>
+#include <TClonesArray.h>
+#include <TTree.h>
+#include <TVirtualMC.h>
+#include <TVirtualMCApplication.h>
+#include <iostream>
+
+
+
+namespace o2
+{
+
+class StepLogger
+{
+  int stepcounter = 0;
+
+  std::set<int> trackset;
+  std::set<int> pdgset;
+  std::map<int, int> volumetosteps;
+  std::map<int, int> volumetohits;
+  std::map<int, std::string> idtovolname;
+  std::map<int, int> volumetoNSecondaries;            // number of secondaries created in this volume
+  std::map<std::pair<int, int>, int> volumetoProcess; // mapping of volumeid x processID to secondaries produced
+
+  std::vector<StepInfo> container;
+  bool mTTreeIO = false;
+  bool mVolMapInitialized = false;
+  // To add a hit to the volume a step was made, set in addStep and used if mTTreeIO == false
+  int mCurrentVolId = -1;
+
+ public:
+
+  StepLogger()
+  {
+    // check if streaming or interactive
+    // configuration done via env variable
+    if (std::getenv("MCSTEPLOG_TTREE")) {
+      mTTreeIO = true;
+    }
+  }
+
+  static StepLogger& Instance()
+  {
+    static StepLogger logger;
+    return logger;
+  }
+
+  void addStep(TVirtualMC* mc)
+  {
+    if (!mVolMapInitialized) {
+      // try to load the volumename -> modulename mapping
+      mcsteploggerutilities::initVolumeMap();
+      StepInfo::lookupstructures.initSensitiveVolLookup(mcsteploggerutilities::getSensitiveVolFile());
+      mVolMapInitialized = true;
+    }
+
+    if (mTTreeIO) {
+      container.emplace_back(mc);
+    } else {
+      assert(mc);
+      stepcounter++;
+
+      auto stack = mc->GetStack();
+      assert(stack);
+      trackset.insert(stack->GetCurrentTrackNumber());
+      pdgset.insert(mc->TrackPid());
+      int copyNo;
+      mCurrentVolId = mc->CurrentVolID(copyNo);
+
+      TArrayI procs;
+      mc->StepProcesses(procs);
+
+      if (volumetosteps.find(mCurrentVolId) == volumetosteps.end()) {
+        volumetosteps.insert(std::pair<int, int>(mCurrentVolId, 0));
+        // At the same time extend hit map
+        volumetohits.insert(std::pair<int, int>(mCurrentVolId, 0));
+      } else {
+        volumetosteps[mCurrentVolId]++;
+      }
+      if (idtovolname.find(mCurrentVolId) == idtovolname.end()) {
+        idtovolname.insert(std::pair<int, std::string>(mCurrentVolId, std::string(mc->CurrentVolName())));
+      }
+
+      // for the secondaries
+      if (volumetoNSecondaries.find(mCurrentVolId) == volumetoNSecondaries.end()) {
+        volumetoNSecondaries.insert(std::pair<int, int>(mCurrentVolId, mc->NSecondaries()));
+      } else {
+        volumetoNSecondaries[mCurrentVolId] += mc->NSecondaries();
+      }
+
+      // for the processes
+      for (int i = 0; i < mc->NSecondaries(); ++i) {
+        auto process = mc->ProdProcess(i);
+        auto p = std::pair<int, int>(mCurrentVolId, process);
+        if (volumetoProcess.find(p) == volumetoProcess.end()) {
+          volumetoProcess.insert(std::pair<std::pair<int, int>, int>(p, 1));
+        } else {
+          volumetoProcess[p]++;
+        }
+      }
+    }
+  }
+
+  void addHit(int detId, int stepId = -1)
+  {
+    if(container.size() == 0) {
+      std::cerr << "Empty step container, exit...\n";
+      exit(1);
+    }
+    if (mTTreeIO) {
+      if(stepId < 0) {
+        container.back().detectorHitId = detId;
+      } else if(stepId < static_cast<int>(container.size())) {
+        container[stepId].detectorHitId = detId;
+      } else {
+        std::cerr << "Step ID " << stepId << " could not be found. Skip hit\n";
+      }
+    } else if(mCurrentVolId >= 0) {
+      volumetohits[mCurrentVolId]++;
+    }
+  }
+
+  void clear()
+  {
+    stepcounter = 0;
+    trackset.clear();
+    pdgset.clear();
+    volumetosteps.clear();
+    volumetohits.clear();
+    idtovolname.clear();
+    volumetoNSecondaries.clear();
+    volumetoProcess.clear();
+    mCurrentVolId = -1;
+    if (mTTreeIO) {
+      container.clear();
+    }
+    StepInfo::resetCounter();
+  }
+
+  // prints list of processes for volumeID
+  void printProcesses(int volid)
+  {
+    for (auto& p : volumetoProcess) {
+      if (p.first.first == volid) {
+        std::cerr << "P[" << TMCProcessName[p.first.second] << "]:" << p.second << "\t";
+      }
+    }
+  }
+
+  void flush()
+  {
+    if (!mTTreeIO) {
+      std::cerr << "[STEPLOGGER]: did " << stepcounter << " steps \n";
+      std::cerr << "[STEPLOGGER]: transported " << trackset.size() << " different tracks \n";
+      std::cerr << "[STEPLOGGER]: transported " << pdgset.size() << " different types \n";
+      // summarize steps per volume
+      for (auto& p : volumetosteps) {
+        std::cerr << "[STEPLOGGER]: VolName " << idtovolname[p.first] << " COUNT steps " << p.second << " SECONDARIES "
+                  << volumetoNSecondaries[p.first] << " COUNT hist " << volumetohits[p.first] << " ";
+        // loop over processes
+        printProcesses(p.first);
+        std::cerr << "\n";
+      }
+      std::cerr << "[STEPLOGGER]: ----- END OF EVENT ------\n";
+    } else {
+      mcsteploggerutilities::flushToTTree("Steps", &container);
+      mcsteploggerutilities::flushToTTree("Lookups", &StepInfo::lookupstructures);
+      // we need to reset some parts of the lookupstructures for the next event
+      StepInfo::lookupstructures.clearTrackLookups();
+    }
+    clear();
+  }
+};
+
+} // namespace o2
+
+#endif /* STEPLOGGER_H_ */

--- a/include/MCStepLogger/StepLoggerUtilities.h
+++ b/include/MCStepLogger/StepLoggerUtilities.h
@@ -1,0 +1,123 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+
+#ifndef STEPLOGGER_UTILITIES_H_
+#define STEPLOGGER_UTILITIES_H_
+
+#include <TBranch.h>
+#include <TClonesArray.h>
+#include <TTree.h>
+#include <TFile.h>
+#include <iostream>
+#include <fstream>
+
+#include <dlfcn.h>
+#include <cstdlib>
+#include <map>
+#include <set>
+#include <sstream>
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <cassert>
+
+namespace o2
+{
+namespace mcsteploggerutilities
+{
+
+  const char* getLogFileName();
+
+  const char* getVolMapFile();
+
+  const char* getSensitiveVolFile();
+
+  // initializes a mapping from volumename to detector
+  // used for step resolution to detectors
+  void initVolumeMap();
+
+  template <typename T>
+  void flushToTTree(const char* branchname, T* address)
+  {
+    TFile* f = new TFile(getLogFileName(), "UPDATE");
+    const char* treename = "StepLoggerTree";
+    auto tree = (TTree*)f->Get(treename);
+    if (!tree) {
+      // create tree
+      tree = new TTree(treename, "Tree container information from MC step logger");
+    }
+    auto branch = tree->GetBranch(branchname);
+    if (!branch) {
+      branch = tree->Branch(branchname, &address);
+    }
+    branch->SetAddress(&address);
+    branch->Fill();
+    tree->SetEntries(branch->GetEntries());
+    // To avoid large number of cycles since whenever the file is opened and things are written, this is done as a new cycle
+    //f->Write();
+    tree->Write("", TObject::kOverwrite);
+    f->Close();
+    delete f;
+  }
+
+  void initTFile();
+
+  // a helper template kernel describing generically the redispatching prodecure
+  template <typename Object /* the original object type */, typename MethodType /* member function type */,
+            typename... Args /* original arguments to function */>
+  void dispatchOriginalKernel(Object* obj, char const* libname, char const* origFunctionName, Args... args)
+  {
+    // Object, MethodType, and Args are of course related so we could do some static_assert checks or automatic deduction
+
+    // static map to avoid having to lookup the right symbols in the shared lib at each call
+    // (We could do this outside of course)
+    static std::map<const char*, MethodType> functionNameToSymbolMap;
+    MethodType origMethod = nullptr;
+
+    auto iter = functionNameToSymbolMap.find(origFunctionName);
+    if (iter == functionNameToSymbolMap.end()) {
+      auto libHandle = dlopen(libname, RTLD_NOW);
+      // try to make the library loading a bit more portable:
+      if (!libHandle) {
+        // try appending *.so
+        std::stringstream stream;
+        stream << libname << ".so";
+        libHandle = dlopen(stream.str().c_str(), RTLD_NOW);
+      }
+      if (!libHandle) {
+        // try appending *.dylib
+        std::stringstream stream;
+        stream << libname << ".dylib";
+        libHandle = dlopen(stream.str().c_str(), RTLD_NOW);
+      }
+      assert(libHandle);
+      void* symbolAddress = dlsym(libHandle, origFunctionName);
+      assert(symbolAddress);
+  // Purposely ignore compiler warning
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wsizeof-pointer-memaccess"
+      // hack since C++ does not allow casting to C++ member function pointers
+      // thanks to gist.github.com/mooware/1174572
+      memcpy(&origMethod, &symbolAddress, sizeof(&symbolAddress));
+  #pragma GCC diagnostic pop
+      functionNameToSymbolMap[origFunctionName] = origMethod;
+    } else {
+      origMethod = iter->second;
+    }
+    // the final C++ member function call redispatch
+    (obj->*origMethod)(args...);
+  }
+
+
+} // namespace mcsteploggerutilities
+} // namespace o2
+
+#endif /* STEPLOGGER_UTILITIES_H_ */

--- a/plugins/O2HitIntercept.cxx
+++ b/plugins/O2HitIntercept.cxx
@@ -1,0 +1,64 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+//  @file   MCStepLoggerImpl.cxx
+//  @author Sandro Wenzel
+//  @since  2017-06-29
+//  @brief  A logging service for MCSteps (hooking into Stepping of TVirtualMCApplication's)
+
+#include "MCStepLogger/StepLogger.h"
+#include "MCStepLogger/StepInfo.h"
+#include "MCStepLogger/StepLoggerUtilities.h"
+//#include "SimulationDataFormat/Stack.h"
+
+#include <dlfcn.h>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <set>
+#include <sstream>
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <cassert>
+
+namespace o2
+{
+namespace data
+{
+
+class Stack
+{
+ public:
+  void addHit(int iDet);
+};
+
+} // namespace data
+} // namespace o2
+
+// a generic function that can dispatch to the original method of a TVirtualMCApplication
+void dispatchOriginalAddHit(o2::data::Stack* stack, char const* libname, char const* origFunctionName, int iDet)
+{
+  using StepMethodType = void (o2::data::Stack::*)(int);
+  o2::mcsteploggerutilities::dispatchOriginalKernel<o2::data::Stack, StepMethodType>(stack, libname, origFunctionName, iDet);
+}
+
+void logHitDetector(int iDet)
+{
+  o2::StepLogger::Instance().addHit(iDet);
+}
+
+void o2::data::Stack::addHit(int iDet)
+{
+  // /auto baseptr = reinterpret_cast<o2::data::Stack*>(this);
+  logHitDetector(iDet);
+  dispatchOriginalAddHit(this, "libSimulationDataFormat", "_ZN2o24data5Stack6addHitEi", iDet);
+}

--- a/src/MCStepLoggerImpl.cxx
+++ b/src/MCStepLoggerImpl.cxx
@@ -15,6 +15,9 @@
 
 #include "MCStepLogger/StepInfo.h"
 #include "MCStepLogger/MetaInfo.h"
+#include "MCStepLogger/StepLogger.h"
+#include "MCStepLogger/FieldLogger.h"
+#include "MCStepLogger/StepLoggerUtilities.h"
 #include <TBranch.h>
 #include <TClonesArray.h>
 #include <TFile.h>
@@ -38,355 +41,19 @@
 #endif
 #include <cassert>
 
-namespace o2
-{
-const char* getLogFileName()
-{
-  if (const char* f = std::getenv("MCSTEPLOG_OUTFILE")) {
-    return f;
-  } else {
-    return "MCStepLoggerOutput.root";
-  }
-}
-
-const char* getVolMapFile()
-{
-  if (const char* f = std::getenv("MCSTEPLOG_VOLMAPFILE")) {
-    return f;
-  } else {
-    return "MCStepLoggerVolMap.dat";
-  }
-}
-
-const char* getSensitiveVolFile()
-{
-  if (const char* f = std::getenv("MCSTEPLOG_SENSVOLFILE")) {
-    return f;
-  } else {
-    return "MCStepLoggerSenVol.dat";
-  }
-}
-
-// initializes a mapping from volumename to detector
-// used for step resolution to detectors
-void initVolumeMap()
-{
-  auto volmap = new std::map<std::string, std::string>;
-  // open for reading or fail
-  std::ifstream ifs;
-  auto f = getVolMapFile();
-  std::cerr << "[MCLOGGER:] TRYING TO READ VOLUMEMAPS FROM " << f << "\n";
-  ifs.open(f);
-  if (ifs.is_open()) {
-    std::string line;
-    while (std::getline(ifs, line)) {
-      std::istringstream ss(line);
-      std::string token;
-      // split the line into key + value
-      int counter = 0;
-      std::string keyvalue[2] = { "NULL", "NULL" };
-      while (counter < 2 && std::getline(ss, token, ':')) {
-        if (!token.empty()) {
-          keyvalue[counter] = token;
-          counter++;
-        }
-      }
-      // put into map
-      volmap->insert({ keyvalue[0], keyvalue[1] });
-    }
-    ifs.close();
-    StepInfo::volnametomodulemap = volmap;
-  } else {
-    std::cerr << "[MCLOGGER:] VOLUMEMAPSFILE NOT FILE\n";
-    StepInfo::volnametomodulemap = nullptr;
-  }
-}
-
-template <typename T>
-void flushToTTree(const char* branchname, T* address)
-{
-  TFile* f = new TFile(getLogFileName(), "UPDATE");
-  const char* treename = "StepLoggerTree";
-  auto tree = (TTree*)f->Get(treename);
-  if (!tree) {
-    // create tree
-    tree = new TTree(treename, "Tree container information from MC step logger");
-  }
-  auto branch = tree->GetBranch(branchname);
-  if (!branch) {
-    branch = tree->Branch(branchname, &address);
-  }
-  branch->SetAddress(&address);
-  branch->Fill();
-  tree->SetEntries(branch->GetEntries());
-  // To avoid large number of cycles since whenever the file is opened and things are written, this is done as a new cycle
-  //f->Write();
-  tree->Write("", TObject::kOverwrite);
-  f->Close();
-  delete f;
-}
-
-void initTFile()
-{
-  if (!std::getenv("MCSTEPLOG_TTREE")) {
-    return;
-  }
-  TFile* f = new TFile(getLogFileName(), "RECREATE");
-  f->Close();
-  delete f;
-}
-
-// a class collecting field access per volume
-class FieldLogger
-{
-  int counter = 0;
-  std::map<int, int> volumetosteps;
-  std::map<int, std::string> idtovolname;
-  bool mTTreeIO = false;
-  std::vector<MagCallInfo> callcontainer;
-
- public:
-  FieldLogger()
-  {
-    // check if streaming or interactive
-    // configuration done via env variable
-    if (std::getenv("MCSTEPLOG_TTREE")) {
-      mTTreeIO = true;
-    }
-  }
-
-  void addStep(TVirtualMC* mc, const double* x, const double* b)
-  {
-    if (mTTreeIO) {
-      callcontainer.emplace_back(mc, x[0], x[1], x[2], b[0], b[1], b[2]);
-      return;
-    }
-    counter++;
-    int copyNo;
-    auto id = mc->CurrentVolID(copyNo);
-    if (volumetosteps.find(id) == volumetosteps.end()) {
-      volumetosteps.insert(std::pair<int, int>(id, 0));
-    } else {
-      volumetosteps[id]++;
-    }
-    if (idtovolname.find(id) == idtovolname.end()) {
-      idtovolname.insert(std::pair<int, std::string>(id, std::string(mc->CurrentVolName())));
-    }
-  }
-
-  void clear()
-  {
-    counter = 0;
-    volumetosteps.clear();
-    idtovolname.clear();
-    if (mTTreeIO) {
-      callcontainer.clear();
-    }
-  }
-
-  void flush()
-  {
-    if (mTTreeIO) {
-      flushToTTree("Calls", &callcontainer);
-    } else {
-      std::cerr << "[FIELDLOGGER]: did " << counter << " steps \n";
-      // summarize steps per volume
-      for (auto& p : volumetosteps) {
-        std::cerr << "[FIELDLOGGER]: VolName " << idtovolname[p.first] << " COUNT " << p.second;
-        std::cerr << "\n";
-      }
-      std::cerr << "[FIELDLOGGER]: ----- END OF EVENT ------\n";
-    }
-    clear();
-  }
-};
-
-class StepLogger
-{
-  int stepcounter = 0;
-
-  std::set<int> trackset;
-  std::set<int> pdgset;
-  std::map<int, int> volumetosteps;
-  std::map<int, std::string> idtovolname;
-  std::map<int, int> volumetoNSecondaries;            // number of secondaries created in this volume
-  std::map<std::pair<int, int>, int> volumetoProcess; // mapping of volumeid x processID to secondaries produced
-
-  std::vector<StepInfo> container;
-  bool mTTreeIO = false;
-  bool mVolMapInitialized = false;
-
- public:
-  StepLogger()
-  {
-    // check if streaming or interactive
-    // configuration done via env variable
-    if (std::getenv("MCSTEPLOG_TTREE")) {
-      mTTreeIO = true;
-    }
-  }
-
-  void addStep(TVirtualMC* mc)
-  {
-    if (!mVolMapInitialized) {
-      // try to load the volumename -> modulename mapping
-      initVolumeMap();
-      StepInfo::lookupstructures.initSensitiveVolLookup(getSensitiveVolFile());
-      mVolMapInitialized = true;
-    }
-
-    if (mTTreeIO) {
-      container.emplace_back(mc);
-    } else {
-      assert(mc);
-      stepcounter++;
-
-      auto stack = mc->GetStack();
-      assert(stack);
-      trackset.insert(stack->GetCurrentTrackNumber());
-      pdgset.insert(mc->TrackPid());
-      int copyNo;
-      auto id = mc->CurrentVolID(copyNo);
-
-      TArrayI procs;
-      mc->StepProcesses(procs);
-
-      if (volumetosteps.find(id) == volumetosteps.end()) {
-        volumetosteps.insert(std::pair<int, int>(id, 0));
-      } else {
-        volumetosteps[id]++;
-      }
-      if (idtovolname.find(id) == idtovolname.end()) {
-        idtovolname.insert(std::pair<int, std::string>(id, std::string(mc->CurrentVolName())));
-      }
-
-      // for the secondaries
-      if (volumetoNSecondaries.find(id) == volumetoNSecondaries.end()) {
-        volumetoNSecondaries.insert(std::pair<int, int>(id, mc->NSecondaries()));
-      } else {
-        volumetoNSecondaries[id] += mc->NSecondaries();
-      }
-
-      // for the processes
-      for (int i = 0; i < mc->NSecondaries(); ++i) {
-        auto process = mc->ProdProcess(i);
-        auto p = std::pair<int, int>(id, process);
-        if (volumetoProcess.find(p) == volumetoProcess.end()) {
-          volumetoProcess.insert(std::pair<std::pair<int, int>, int>(p, 1));
-        } else {
-          volumetoProcess[p]++;
-        }
-      }
-    }
-  }
-
-  void clear()
-  {
-    stepcounter = 0;
-    trackset.clear();
-    pdgset.clear();
-    volumetosteps.clear();
-    idtovolname.clear();
-    volumetoNSecondaries.clear();
-    volumetoProcess.clear();
-    if (mTTreeIO) {
-      container.clear();
-    }
-    StepInfo::resetCounter();
-  }
-
-  // prints list of processes for volumeID
-  void printProcesses(int volid)
-  {
-    for (auto& p : volumetoProcess) {
-      if (p.first.first == volid) {
-        std::cerr << "P[" << TMCProcessName[p.first.second] << "]:" << p.second << "\t";
-      }
-    }
-  }
-
-  void flush()
-  {
-    if (!mTTreeIO) {
-      std::cerr << "[STEPLOGGER]: did " << stepcounter << " steps \n";
-      std::cerr << "[STEPLOGGER]: transported " << trackset.size() << " different tracks \n";
-      std::cerr << "[STEPLOGGER]: transported " << pdgset.size() << " different types \n";
-      // summarize steps per volume
-      for (auto& p : volumetosteps) {
-        std::cerr << "[STEPLOGGER]: VolName " << idtovolname[p.first] << " COUNT " << p.second << " SECONDARIES "
-                  << volumetoNSecondaries[p.first] << " ";
-        // loop over processes
-        printProcesses(p.first);
-        std::cerr << "\n";
-      }
-      std::cerr << "[STEPLOGGER]: ----- END OF EVENT ------\n";
-    } else {
-      flushToTTree("Steps", &container);
-      flushToTTree("Lookups", &StepInfo::lookupstructures);
-      // we need to reset some parts of the lookupstructures for the next event
-      StepInfo::lookupstructures.clearTrackLookups();
-    }
-    clear();
-  }
-};
-
 // the global logging instances (in anonymous namespace)
 // pointers to dissallow construction at each library load
+// NOTE in case something breaks
+namespace o2 {
 StepLogger* logger;
 FieldLogger* fieldlogger;
-} // end namespace
-
-// a helper template kernel describing generically the redispatching prodecure
-template <typename Object /* the original object type */, typename MethodType /* member function type */,
-          typename... Args /* original arguments to function */>
-void dispatchOriginalKernel(Object* obj, char const* libname, char const* origFunctionName, Args... args)
-{
-  // Object, MethodType, and Args are of course related so we could do some static_assert checks or automatic deduction
-
-  // static map to avoid having to lookup the right symbols in the shared lib at each call
-  // (We could do this outside of course)
-  static std::map<const char*, MethodType> functionNameToSymbolMap;
-  MethodType origMethod = nullptr;
-
-  auto iter = functionNameToSymbolMap.find(origFunctionName);
-  if (iter == functionNameToSymbolMap.end()) {
-    auto libHandle = dlopen(libname, RTLD_NOW);
-    // try to make the library loading a bit more portable:
-    if (!libHandle) {
-      // try appending *.so
-      std::stringstream stream;
-      stream << libname << ".so";
-      libHandle = dlopen(stream.str().c_str(), RTLD_NOW);
-    }
-    if (!libHandle) {
-      // try appending *.dylib
-      std::stringstream stream;
-      stream << libname << ".dylib";
-      libHandle = dlopen(stream.str().c_str(), RTLD_NOW);
-    }
-    assert(libHandle);
-    void* symbolAddress = dlsym(libHandle, origFunctionName);
-    assert(symbolAddress);
-// Purposely ignore compiler warning
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wsizeof-pointer-memaccess"
-    // hack since C++ does not allow casting to C++ member function pointers
-    // thanks to gist.github.com/mooware/1174572
-    memcpy(&origMethod, &symbolAddress, sizeof(&symbolAddress));
-#pragma GCC diagnostic pop
-    functionNameToSymbolMap[origFunctionName] = origMethod;
-  } else {
-    origMethod = iter->second;
-  }
-  // the final C++ member function call redispatch
-  (obj->*origMethod)(args...);
 }
 
 // a generic function that can dispatch to the original method of a TVirtualMCApplication
 extern "C" void dispatchOriginal(TVirtualMCApplication* app, char const* libname, char const* origFunctionName)
 {
   typedef void (TVirtualMCApplication::*StepMethodType)();
-  dispatchOriginalKernel<TVirtualMCApplication, StepMethodType>(app, libname, origFunctionName);
+  o2::mcsteploggerutilities::dispatchOriginalKernel<TVirtualMCApplication, StepMethodType>(app, libname, origFunctionName);
 }
 
 // a generic function that can dispatch to the original method of a TVirtualMagField
@@ -394,7 +61,7 @@ extern "C" void dispatchOriginalField(TVirtualMagField* field, char const* libna
                                       const double x[3], double* B)
 {
   typedef void (TVirtualMagField::*MethodType)(const double[3], double*);
-  dispatchOriginalKernel<TVirtualMagField, MethodType>(field, libname, origFunctionName, x, B);
+  o2::mcsteploggerutilities::dispatchOriginalKernel<TVirtualMagField, MethodType>(field, libname, origFunctionName, x, B);
 }
 
 extern "C" void performLogging(TVirtualMCApplication* app)
@@ -412,10 +79,10 @@ extern "C" void logField(double const* p, double const* b)
 extern "C" void initLogger()
 {
   // init TFile for logging output
-  o2::initTFile();
+  o2::mcsteploggerutilities::initTFile();
   // initializes the logging instances
-  o2::logger = new o2::StepLogger();
-  o2::fieldlogger = new o2::FieldLogger();
+  o2::logger = &o2::StepLogger::Instance();
+  o2::fieldlogger = &o2::FieldLogger::Instance();
 }
 
 extern "C" void flushLog()

--- a/src/StepInfo.cxx
+++ b/src/StepInfo.cxx
@@ -114,7 +114,7 @@ StepInfo::StepInfo(TVirtualMC* mc)
   if (nsecondaries > 0) {
     lookupstructures.setProducedSecondary(trackID, true);
   }
-  
+
   if (mc->IsTrackExiting()) {
     lookupstructures.setCrossedBoundary(trackID, true);
   }
@@ -139,7 +139,7 @@ StepInfo::StepInfo(TVirtualMC* mc)
 const char* StepInfo::getProdProcessAsString() const {
   return TMCProcessName[prodprocess];
 }
-  
+
 std::chrono::time_point<std::chrono::high_resolution_clock> StepInfo::starttime;
 int StepInfo::stepcounter = -1;
 std::map<std::string, std::string>* StepInfo::volnametomodulemap = nullptr;
@@ -161,6 +161,8 @@ int MagCallInfo::stepcounter = -1;
 // the current ROOT geometry loaded
 bool StepLookups::initSensitiveVolLookup(const std::string& filename)
 {
+
+  
   if (!gGeoManager) {
     std::cerr << "[MCSTEPLOG] : Cannot setup sensitive lookup since GeoManager not found \n";
     return false;

--- a/src/StepLoggerUtilities.cxx
+++ b/src/StepLoggerUtilities.cxx
@@ -1,0 +1,93 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+
+#include "MCStepLogger/StepLoggerUtilities.h"
+#include "MCStepLogger/StepInfo.h"
+
+namespace o2
+{
+namespace mcsteploggerutilities
+{
+
+const char* getLogFileName()
+{
+  if (const char* f = std::getenv("MCSTEPLOG_OUTFILE")) {
+    return f;
+  } else {
+    return "MCStepLoggerOutput.root";
+  }
+}
+
+const char* getVolMapFile()
+{
+  if (const char* f = std::getenv("MCSTEPLOG_VOLMAPFILE")) {
+    return f;
+  } else {
+    return "MCStepLoggerVolMap.dat";
+  }
+}
+
+const char* getSensitiveVolFile()
+{
+  if (const char* f = std::getenv("MCSTEPLOG_SENSVOLFILE")) {
+    return f;
+  } else {
+    return "MCStepLoggerSenVol.dat";
+  }
+}
+
+// initializes a mapping from volumename to detector
+// used for step resolution to detectors
+void initVolumeMap()
+{
+  auto volmap = new std::map<std::string, std::string>;
+  // open for reading or fail
+  std::ifstream ifs;
+  auto f = getVolMapFile();
+  std::cerr << "[MCLOGGER:] TRYING TO READ VOLUMEMAPS FROM " << f << "\n";
+  ifs.open(f);
+  if (ifs.is_open()) {
+    std::string line;
+    while (std::getline(ifs, line)) {
+      std::istringstream ss(line);
+      std::string token;
+      // split the line into key + value
+      int counter = 0;
+      std::string keyvalue[2] = { "NULL", "NULL" };
+      while (counter < 2 && std::getline(ss, token, ':')) {
+        if (!token.empty()) {
+          keyvalue[counter] = token;
+          counter++;
+        }
+      }
+      // put into map
+      volmap->insert({ keyvalue[0], keyvalue[1] });
+    }
+    ifs.close();
+    StepInfo::volnametomodulemap = volmap;
+  } else {
+    std::cerr << "[MCLOGGER:] VOLUMEMAPSFILE NOT FILE\n";
+    StepInfo::volnametomodulemap = nullptr;
+  }
+}
+
+void initTFile()
+{
+  if (!std::getenv("MCSTEPLOG_TTREE")) {
+    return;
+  }
+  TFile* f = new TFile(getLogFileName(), "RECREATE");
+  f->Close();
+  delete f;
+}
+
+} // namespace mcsteploggerutilities
+} // namespace o2


### PR DESCRIPTION
Extract StepLogger and FieldLogger from MCStepLoggerImpl.cxx in order to
allow for naturally use and integrate these objects in external code.

The hit field to StepInfo is added to flag whether a step has produced a
hit. This could be extended to contain more info of the hit like
deposited energy, spatial coordinates etc.

A use case will be added to the O2 simulation.

[WIP] label until final decision on specific histograms to be added for the SimpleStepAnalysis is made.