### PR TITLE
Various updates and fixes

### DIFF
--- a/MCReplay/README.md
+++ b/MCReplay/README.md
@@ -4,32 +4,36 @@ This is a pseudo-detector-simulation engine based on the [Virtual Monte Carlo (V
 
 The main objective is to be able to provide an engine to study the impact of parameter variations with. Eventually, this can be used to optimise (full-)simulation parameters in view of enhancing their speed and efficiency.
 
-The functionality is compiled into a separate library `libTMCReplay` which also allows to use the `libMCStepLoggerIntercept` which also allows to run the step logging against the `TMCReplay` engine.
+The functionality is compiled into a separate library `libMCReplayCore`. Hence, `libMCStepLoggerIntercept` is completely independent which also allows to run the step logging against the `MCReplayEngine` engine.
+
+The replay has been tested and is verified against [GEANT3_VMC](https://github.com/vmc-project/geant3) and [GEANT4_VMC](https://github.com/vmc-project/geant4_vmc) VMC interfaces.
 
 ## Setting parameters
 
-The list of tunable parameters is foreseen to correspond to the possible settings implemented for [GEANT3_VMC]() and [GEANT4_VMC](https://github.com/vmc-project/geant4_vmc) and can be found [here](include/TMCReplay/Physics.h). The parameters can be set via the usual interfaces
-* `TVirtualMC::SetCut` and `TVirtualMC::SetProcess` to set global cut and process values
-* `TVirtualMC::Gstpar` to set parameters depending on a certain medium
+The list of tunable parameters is foreseen to correspond to the possible settings implemented for GEANT3_VMC and GEANT4_VMC and can be found [here](include/MCReplay/MCReplayPhysics.h). The parameters can be set via the usual interfaces
+* `TVirtualMC::SetCut` and `TVirtualMC::SetProcess` to set global cut and process values,
+* `TVirtualMC::Gstpar` to set parameters depending on a certain medium.
+The cut parameters act like production cuts.
 
 **Please note** that the parameters can be set but at the moment nothing is actually applied. Therefore, the exact same steps would be reproduced regardless of the parameters. Of course, this is the next major development as it is one of the core objectives of this engine.
+**On the other hand**, there is one special parameter called `CUTALLE` which is an energy production cut on **any** PDG which can also be set through the aforementioned interfaces. Note, that this parameter has no meaning to GEANT3_VMC or GEANT4_VMC.
 
 ## Testing different parameter settings
 
-**Note that this section becomes actually meaningful when the aforementioned functionality will have been implemented.** However, in the current state it can already be verified that the `TMCReplay` engine does what it is supposed to do.
+**Note that this section becomes actually meaningful when the aforementioned functionality will have been implemented.** However, in the current state it can already be verified that the `MCReplayEngine` engine does what it is supposed to do.
 
-### Running/testing on step level only (`TMCReplayDummyApplication` and `TMCReplayDummyStack`)
+### Running/testing on step level only (`MCReplayGenericApplication` and `MCReplayGenericStack`)
 
-If only the impact on the steps is desired, all required functionality is already included here. Simply have a look at [this executable](src/replay.cxx). It makes use of the `TMCReplayDummyApplication` and `TMCReplayDummyStack` just to replay the steps. Once implemented, the impact of the parameters on the stepping can be evaluated with this tool alone. To do so, just run the `MCStepLogger` together with the replay, for instance as follows
+If only the replay of steps is desired, all required functionality is already included here, completely independent of any environment the reference run was done. Simply have a look at [this code](src/replay.cxx) serving as the source for the executable `mcreplay`. It makes use of the `MCReplayGenericApplication` and `MCReplayGenericStack` just to replay the steps. Once implemented, the impact of the parameters on the stepping can be evaluated with this tool alone. To do so, just run the `MCStepLogger` followed by the replay, for instance as follows (assuming  everything was setup with `aliBuild`)
 
 ```bash
-MCSTEPLOG_TTREE=1 LD_PRELOAD=$MCSTEPLOGGER_ROOT/lib/libMCStepLoggerIntercept.so tmcreplay
+MCSTEPLOG_TTREE=1 LD_PRELOAD=$MCSTEPLOGGER_ROOT/lib/libMCStepLoggerIntercept.so mcreplay
 ```
 
 That will pick up the step file `MCStepLoggerOutput.root`. If you gave that a different name (or in case also your contained tree has another name), you will find the following help message useful:
 
 ```bash
-> tmcreplay --help
+> mcreplay --help
 Replaying a previously recorded particle transport step-by-step. Mainly meant for checking and performance measurements/optimisation of the transport:
   --help                                show this help message and exit
   --stepfilename arg (=MCStepLoggerOutput.root)
@@ -40,13 +44,18 @@ Replaying a previously recorded particle transport step-by-step. Mainly meant fo
                                         ROOT geometry filename
   --geokeyname arg (=FAIRGeom)          key name inside geo file where to find
                                         geometry tree
-
+  -n [ --nevents ] arg (=-1)            number of events to replay
+  -e [ --energycut ] arg (=-1)          energy cut to be applied [GeV]
 ```
 
-As you can see the geometry is required by this executable as well since it has otherwise no idea what geometry was used for the original simulation.
+As you can see the geometry is required by this executable as well since it has otherwise no idea what the geometry should look like from the `MCStepLoggerOutput.root` file alone.
 
 ### Running in another environment
 
 In that case the geometry construction is assumed to implemented by that environment's implementation of `TVirtualMCApplication`. Also, no stack is constructed automatically and it has to be constructed and passed by the user.
 
 Such a scenario is useful to evaluate the impact of parameter variation on hits or even digits.
+
+## Using the engine as a full simulation engine
+
+The `MCReplayEngine` has been tested with the [ALICE O2 framework](https://github.com/AliceO2Group/AliceO2) and also hits can be reproduced sufficiently which allows for realistic parameter tuning.

--- a/MCReplay/include/MCReplay/MCReplayEngine.h
+++ b/MCReplay/include/MCReplay/MCReplayEngine.h
@@ -1047,7 +1047,8 @@ class MCReplayEngine : public TVirtualMC
   // TODO To be implemented
   virtual void ProcessEvent() override
   {
-    Warning("ProcessEvent", "Not yet implemented");
+    // Here we assume that the transport of the next event is desired
+    ProcessEvent(mCurrentEvent);
   }
 
   /// Process one  run and return true if run has finished successfully,

--- a/MCReplay/include/MCReplay/MCReplayPhysics.h
+++ b/MCReplay/include/MCReplay/MCReplayPhysics.h
@@ -23,8 +23,8 @@ namespace physics
 constexpr std::array<const char*, 15> namesProcesses = {"PAIR", "COMP", "PHOT", "PFIS", "DRAY", "ANNI", "BREM", "HADR", "MUNU", "DCAY", "LOSS", "MULS", "CKOV", "RAYL", "LABS"};
 // standard GEANT cut parameter names (1-11)
 // additional Replay cut parameter names (12-n):
-// ALLE: energy cut applying to all tracks independent of PDG
-constexpr std::array<const char*, 12> namesCuts = {"CUTGAM", "CUTELE", "CUTNEU", "CUTHAD", "CUTMUO", "NCUTE", "BCUTM", "DCUTE", "DCUTM", "PPCUTM", "TOFMAX", "ALLE"};
+// CUTALLE: energy cut applying to all tracks independent of PDG
+constexpr std::array<const char*, 12> namesCuts = {"CUTGAM", "CUTELE", "CUTNEU", "CUTHAD", "CUTMUO", "NCUTE", "BCUTM", "DCUTE", "DCUTM", "PPCUTM", "TOFMAX", "CUTALLE"};
 constexpr const char* unknownParam = "UNKNOWN";
 
 template <typename T, std::size_t N>

--- a/MCReplay/src/MCReplayEvGen.cxx
+++ b/MCReplay/src/MCReplayEvGen.cxx
@@ -34,6 +34,7 @@ MCReplayEvGen::~MCReplayEvGen()
 {
   if (mStepFile) {
     mStepFile->Close();
+    delete mStepFile;
   }
 }
 
@@ -67,8 +68,7 @@ bool MCReplayEvGen::next(TVirtualMCStack* stack)
     return false;
   }
 
-  // flag if we found at least one primary
-  bool foundPrimary{false};
+  int nPrimaries{0};
 
   // just provide for pushing to stack, nothing else
   int stackTrackID;
@@ -85,13 +85,13 @@ bool MCReplayEvGen::next(TVirtualMCStack* stack)
     if (!step.newtrack || lookups->tracktoparent[step.trackID] >= 0) {
       continue;
     }
-    std::cout << "Push primary " << step.trackID << " with PDG " << lookups->tracktopdg[step.trackID] << " to stack" << std::endl;
-    foundPrimary = true;
+    nPrimaries++;
     stack->PushTrack(1, -1, lookups->tracktopdg[step.trackID], step.px, step.py, step.pz, step.E, step.x, step.y, step.z, step.t, 1., 1., 1., TMCProcess(step.prodprocess), stackTrackID, 1., 0);
   }
+  std::cout << "Pushed " << nPrimaries << " onto the stack\n";
   // No longer needed
   delete steps;
   delete lookups;
   mEventCounter++;
-  return foundPrimary;
+  return nPrimaries > 0;
 }

--- a/MCReplay/src/replay.cxx
+++ b/MCReplay/src/replay.cxx
@@ -53,7 +53,7 @@ int main(int argc, char* argv[])
   app.setEvGen(&gen);
   mc.SetStack(&stack);
   if (cut > 0.) {
-    mc.SetCut("ALLE", cut);
+    mc.SetCut("CUTALLE", cut);
   }
   mc.Init();
 

--- a/MCStepLogger/include/MCStepLogger/StepInfo.h
+++ b/MCStepLogger/include/MCStepLogger/StepInfo.h
@@ -57,6 +57,7 @@ struct StepLookups {
   std::vector<std::string*> volidtovolname;
   std::vector<std::string*> volidtomodule;
   std::vector<std::string*> volidtomedium;
+  std::vector<int> geovolidtovmcvolid;
   std::vector<bool> volidtoissensitive; // keep track of which volume is sensitive
   std::vector<int> tracktopdg;
   std::vector<float> tracktocharge;
@@ -151,6 +152,7 @@ struct StepLookups {
   }
 
   bool initSensitiveVolLookup(std::string const& filename);
+  bool initGeoVolIdToVMCVolid(TVirtualMC* mc);
 
   void insertParent(int trackindex, int parent)
   {
@@ -233,6 +235,7 @@ struct StepInfo {
   bool outside = false;           // if track is outside world
   bool newtrack = false;          // if track is new
   bool insensitiveRegion = false; // whether step done in sensitive region
+  std::string* geopath = nullptr;
 
   const char* getProdProcessAsString() const;
 

--- a/MCStepLogger/include/MCStepLogger/StepInfo.h
+++ b/MCStepLogger/include/MCStepLogger/StepInfo.h
@@ -72,6 +72,7 @@ struct StepLookups {
 
   void insertVolName(int index, std::string const& s) { insertValueAt(index, s, volidtovolname); }
   void insertModuleName(int index, std::string const& s) { insertValueAt(index, s, volidtomodule); }
+  void insertMediumName(int index, std::string const& s) { insertValueAt(index, s, volidtomedium); }
   std::string* getModuleAt(int index) const
   {
     if (index >= volidtomodule.size())

--- a/MCStepLogger/src/MCStepLoggerImpl.cxx
+++ b/MCStepLogger/src/MCStepLoggerImpl.cxx
@@ -233,6 +233,7 @@ class StepLogger
       // try to load the volumename -> modulename mapping
       initVolumeMap();
       StepInfo::lookupstructures.initSensitiveVolLookup(getSensitiveVolFile());
+      StepInfo::lookupstructures.initGeoVolIdToVMCVolid(mc);
       mVolMapInitialized = true;
     }
 

--- a/MCStepLogger/src/StepInfo.cxx
+++ b/MCStepLogger/src/StepInfo.cxx
@@ -62,7 +62,6 @@ StepInfo::StepInfo(TVirtualMC* mc)
   // try to resolve the module via external map
   // keep information in faster vector once looked up
   auto volname = mc->CurrentVolName();
-  lookupstructures.insertVolName(volId, volname);
 
   if (volnametomodulemap && volnametomodulemap->size() > 0 && volId >= 0) {
     if (lookupstructures.getModuleAt(volId) == nullptr) {
@@ -228,10 +227,14 @@ bool StepLookups::initGeoVolIdToVMCVolid(TVirtualMC* mc)
 
   while (obj = voliter->Next()) {
     if (vol = dynamic_cast<TGeoVolume*>(obj)) {
+      auto volIdVMC{mc->VolId(vol->GetName())};
+      insertVolName(volIdVMC, vol->GetName());
+      insertMediumName(volIdVMC, vol->GetMedium()->GetName());
+
       if (geovolidtovmcvolid.size() <= vol->GetNumber()) {
         geovolidtovmcvolid.resize(vol->GetNumber() + 1, -1);
       }
-      geovolidtovmcvolid[vol->GetNumber()] = mc->VolId(vol->GetName());
+      geovolidtovmcvolid[vol->GetNumber()] = volIdVMC;
     }
   }
   return true;


### PR DESCRIPTION
* store TGeoManager::GetPath() in MCStepLogger if track enters to
  restore geometry in replay. This is necessary in particular in case of
  steps on or in the vincinity of boundaries. Floating point precision
  might not be enough to find a node based on spatial coordinates. In
  addition, restoring from the path makes navigation and node finding
  obsolete during replay

* extract TGEoVolume ID to VMC volume ID mapping. These are not the same
  for Geant4_VMC hence it is necessary. Mapping is required in replay,
  otheriwse, hit processing can fail.
  Mapping during replay is skipped if it is the identity.

* make replay work for Geant4_VMC. This works thanks to above additions.

* add possibility to load a custom user keepStep function from a ROOT
  macro

* additional small fixes