### PR TITLE
Refine replay and correct installation on Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,26 @@ SET(INSTALL_INC_DIR ${CMAKE_INSTALL_PREFIX}/include)
 SET(INSTALL_LIB_DIR ${CMAKE_INSTALL_PREFIX}/lib)
 SET(INSTALL_CMAKE_DIR ${CMAKE_INSTALL_PREFIX}/cmake)
 
+# setup for rpath and mac on the shoulders of O2 CMake
+include(GNUInstallDirs)
+if (APPLE)
+  set(basePoint @loader_path)
+else()
+  set(basePoint $ORIGIN)
+endif()
+set(CMAKE_SKIP_BUILD_RPATH FALSE)
+if (APPLE)
+  set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+endif()
+
+# add to the install RPATH the (automatically determined) parts of the RPATH
+# that point to directories outside the build tree
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+# specify libraries directory relative to binaries one.
+file(RELATIVE_PATH relDir ${INSTALL_BIN_DIR} ${INSTALL_LIB_DIR})
+set(CMAKE_INSTALL_RPATH ${basePoint} ${basePoint}/${relDir})
+
 #################################
 # Whether or not to build tests #
 #################################

--- a/MCReplay/include/MCReplay/MCReplayEngine.h
+++ b/MCReplay/include/MCReplay/MCReplayEngine.h
@@ -663,7 +663,7 @@ class MCReplayEngine : public TVirtualMC
   /// Set the maximum step allowed till the particle is in the current medium
   virtual void SetMaxStep(Double_t) override
   {
-    //Warning("SetMaxStep", "Not yet implemented");
+    // Warning("SetMaxStep", "Not yet implemented");
   }
 
   /// Set the maximum number of steps till the particle is in the current medium
@@ -1015,7 +1015,7 @@ class MCReplayEngine : public TVirtualMC
   virtual Int_t StepProcesses(TArrayI& proc) const override
   {
     // TODO Not possible atm with MCStepLogger, donet have that info
-    //Warning("StepProcesses", "Not yet implemented");
+    // Warning("StepProcesses", "Not yet implemented");
     return -1;
   }
 
@@ -1166,7 +1166,7 @@ class MCReplayEngine : public TVirtualMC
 
   // add process or cut values based on name and value
   template <typename P, typename T, std::size_t N>
-  bool insertProcessOrCut(std::vector<std::vector<P>*>& insertInto, const std::array<T, N>& allParamsNames, const std::vector<P>& defaultParams, Int_t mediumId, const char* paramName, P parval, bool forceSet=false)
+  bool insertProcessOrCut(std::vector<std::vector<P>*>& insertInto, const std::array<T, N>& allParamsNames, const std::vector<P>& defaultParams, Int_t mediumId, const char* paramName, P parval, bool forceSet = false)
   {
     auto paramIndex = physics::paramToIndex(allParamsNames, paramName);
     return insertProcessOrCut(insertInto, allParamsNames, defaultParams, mediumId, paramIndex, parval, forceSet);
@@ -1174,7 +1174,7 @@ class MCReplayEngine : public TVirtualMC
 
   // add process or cut values based on name and value
   template <typename P, typename T, std::size_t N>
-  bool insertProcessOrCut(std::vector<std::vector<P>*>& insertInto, const std::array<T, N>& allParamsNames, const std::vector<P>& defaultParams, Int_t mediumId, int paramIndex, P parval, bool forceSet=false)
+  bool insertProcessOrCut(std::vector<std::vector<P>*>& insertInto, const std::array<T, N>& allParamsNames, const std::vector<P>& defaultParams, Int_t mediumId, int paramIndex, P parval, bool forceSet = false)
   {
     if (paramIndex < 0) {
       return false;
@@ -1197,14 +1197,14 @@ class MCReplayEngine : public TVirtualMC
   }
 
   template <typename P, typename T, std::size_t N>
-  bool insertProcessOrCut(std::vector<P>& insertInto, const std::array<T, N>& allParamsNames, const char* paramName, P parval, bool forceSet=false)
+  bool insertProcessOrCut(std::vector<P>& insertInto, const std::array<T, N>& allParamsNames, const char* paramName, P parval, bool forceSet = false)
   {
     auto paramIndex = physics::paramToIndex(allParamsNames, paramName);
     return insertProcessOrCut(insertInto, allParamsNames, paramIndex, parval, forceSet);
   }
 
   template <typename P, typename T, std::size_t N>
-  bool insertProcessOrCut(std::vector<P>& insertInto, const std::array<T, N>& allParamsNames, int paramIndex, P parval, bool forceSet=false)
+  bool insertProcessOrCut(std::vector<P>& insertInto, const std::array<T, N>& allParamsNames, int paramIndex, P parval, bool forceSet = false)
   {
     if (paramIndex < 0) {
       return false;

--- a/MCReplay/src/MCReplayEngine.cxx
+++ b/MCReplay/src/MCReplayEngine.cxx
@@ -909,7 +909,6 @@ void MCReplayEngine::Gstpar(Int_t itmed, const char* param, Double_t parval)
   }
 }
 
-
 void MCReplayEngine::loadCurrentCutsAndProcesses(int volId)
 {
   mCurrentProcesses = &mProcessesGlobal;

--- a/MCStepLogger/src/MCStepLoggerImpl.cxx
+++ b/MCStepLogger/src/MCStepLoggerImpl.cxx
@@ -336,6 +336,7 @@ class StepLogger
 // pointers to dissallow construction at each library load
 StepLogger* logger;
 FieldLogger* fieldlogger;
+bool doFieldLogging = std::getenv("MCSTEPLOG_NO_FIELD") ? false : true;
 } // namespace o2
 
 // a helper template kernel describing generically the redispatching prodecure
@@ -407,8 +408,10 @@ extern "C" void performLogging(TVirtualMCApplication* app)
 
 extern "C" void logField(double const* p, double const* b)
 {
-  static TVirtualMC* mc = TVirtualMC::GetMC();
-  o2::fieldlogger->addStep(mc, p, b);
+  if (o2::doFieldLogging) {
+    static TVirtualMC* mc = TVirtualMC::GetMC();
+    o2::fieldlogger->addStep(mc, p, b);
+  }
 }
 
 extern "C" void initLogger()

--- a/MCStepLogger/src/MCStepLoggerImpl.cxx
+++ b/MCStepLogger/src/MCStepLoggerImpl.cxx
@@ -121,7 +121,7 @@ void flushToTTree(const char* branchname, T* address)
   branch->Fill();
   tree->SetEntries(branch->GetEntries());
   // To avoid large number of cycles since whenever the file is opened and things are written, this is done as a new cycle
-  //f->Write();
+  // f->Write();
   tree->Write("", TObject::kOverwrite);
   f->Close();
   delete f;


### PR DESCRIPTION
* Set r-path for Mac correctly
*  [MCReplay] Updates
    * optionally allow to handle StopTrack
    * make skipTrack time-dependent instead of simple bool
      This allows to skip also tracks that would have followed later
      after a StopTrack request was issued
    * Move some functionality to functions
* Disable field logging on request (MCSTEPLOG_NO_FIELD=1)