### PR TITLE
Fix for C++20

### DIFF
--- a/MCStepLogger/include/MCStepLogger/MCAnalysisManager.h
+++ b/MCStepLogger/include/MCStepLogger/MCAnalysisManager.h
@@ -31,6 +31,7 @@
 
 #include "MCStepLogger/StepInfo.h"
 #include "MCStepLogger/MetaInfo.h"
+#include "MCStepLogger/MCAnalysisFileWrapper.h"
 
 namespace o2
 {
@@ -38,7 +39,6 @@ namespace mcstepanalysis
 {
 
 class MCAnalysis;
-class MCAnalysisFileWrapper;
 
 class MCAnalysisManager
 {


### PR DESCRIPTION
std::vector has a constexpr destructor in C++20, which makes forward declaration not viable anymore.