### PR TITLE
Fix compilation problem and compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,18 +104,26 @@ find_package(Boost COMPONENTS program_options chrono unit_test_framework REQUIRE
 ###############################
 # Determine CXX STD from ROOT #
 ###############################
-SET(CMAKE_CXX_STANDARD 11)
+
+#
+# SW: The following code was there but was
+# problematic. In principle, we expect the C++ version
+# to be set from the outside via (-DCMAKE_CXX_STANDARD).
+# Please send email if this does not work for you.
+#
+
+#SET(CMAKE_CXX_STANDARD 11)
 # Find ROOT CXX standard
-string(FIND ${ROOT_CXX_FLAGS} "-std=" POSITION)
-if (${POSITION} GREATER -1)
-    string(SUBSTRING ${ROOT_CXX_FLAGS} ${POSITION} 11 ROOT_CXX_STD)
-    if(${ROOT_CXX_STD} STREQUAL "-std=c++1z " OR ${ROOT_CXX_STD} STREQUAL "-std=c++17 ")
-        SET(CMAKE_CXX_STANDARD 17)
-    elseif(${ROOT_CXX_STD} STREQUAL "-std=c++1y " OR ${ROOT_CXX_STD} STREQUAL "-std=c++14 ")
-        SET(CMAKE_CXX_STANDARD 14)
-    endif()
-endif()
-message(STATUS "Build with CXX STD ${CMAKE_CXX_STANDARD}")
+#string(FIND ${ROOT_CXX_FLAGS} "-std=" POSITION)
+#if (${POSITION} GREATER -1)
+#    string(SUBSTRING ${ROOT_CXX_FLAGS} ${POSITION} 11 ROOT_CXX_STD)
+#    if(${ROOT_CXX_STD} STREQUAL "-std=c++1z " OR ${ROOT_CXX_STD} STREQUAL "-std=c++17 ")
+#        SET(CMAKE_CXX_STANDARD 17)
+#    elseif(${ROOT_CXX_STD} STREQUAL "-std=c++1y " OR ${ROOT_CXX_STD} STREQUAL "-std=c++14 ")
+#        SET(CMAKE_CXX_STANDARD 14)
+#    endif()
+#endif()
+#message(STATUS "Build with CXX STD ${CMAKE_CXX_STANDARD}")
 
 #######################
 # Do the installation #

--- a/MCReplay/include/MCReplay/MCReplayEngine.h
+++ b/MCReplay/include/MCReplay/MCReplayEngine.h
@@ -60,7 +60,7 @@ class MCReplayEngine : public TVirtualMC
   //
 
   /// Info about supporting geometry defined via Root
-  virtual Bool_t IsRootGeometrySupported() const override
+  Bool_t IsRootGeometrySupported() const override
   {
     return kTRUE;
   }
@@ -84,10 +84,10 @@ class MCReplayEngine : public TVirtualMC
   ///               calculates it, if <0. -radl is taken
   /// - buf    pointer to an array of user words
   /// - nwbuf  number of user words
-  virtual void Material(Int_t& kmat, const char* name, Double_t a, Double_t z, Double_t dens, Double_t radl, Double_t absl, Float_t* buf, Int_t nwbuf) override;
+  void Material(Int_t& kmat, const char* name, Double_t a, Double_t z, Double_t dens, Double_t radl, Double_t absl, Float_t* buf, Int_t nwbuf) override;
 
   /// The same as previous but in double precision
-  virtual void Material(Int_t& kmat, const char* name, Double_t a, Double_t z, Double_t dens, Double_t radl, Double_t absl, Double_t* buf, Int_t nwbuf) override;
+  void Material(Int_t& kmat, const char* name, Double_t a, Double_t z, Double_t dens, Double_t radl, Double_t absl, Double_t* buf, Int_t nwbuf) override;
 
   /// Define a mixture or a compound
   /// with a number kmat composed by the basic nlmat materials defined
@@ -100,10 +100,10 @@ class MCReplayEngine : public TVirtualMC
   /// of a given kind into the molecule of the compound.
   /// In this case, wmat in output is changed to relative
   /// weights.
-  virtual void Mixture(Int_t& kmat, const char* name, Float_t* a, Float_t* z, Double_t dens, Int_t nlmat, Float_t* wmat) override;
+  void Mixture(Int_t& kmat, const char* name, Float_t* a, Float_t* z, Double_t dens, Int_t nlmat, Float_t* wmat) override;
 
   /// The same as previous but in double precision
-  virtual void Mixture(Int_t& kmat, const char* name, Double_t* a, Double_t* z, Double_t dens, Int_t nlmat, Double_t* wmat) override;
+  void Mixture(Int_t& kmat, const char* name, Double_t* a, Double_t* z, Double_t dens, Int_t nlmat, Double_t* wmat) override;
 
   /// Define a medium.
   /// - kmed      tracking medium number assigned
@@ -124,10 +124,10 @@ class MCReplayEngine : public TVirtualMC
   /// - stmin     min. step due to continuous processes (cm)
   /// - ubuf      pointer to an array of user words
   /// - nbuf      number of user words
-  virtual void Medium(Int_t& kmed, const char* name, Int_t nmat, Int_t isvol, Int_t ifield, Double_t fieldm, Double_t tmaxfd, Double_t stemax, Double_t deemax, Double_t epsil, Double_t stmin, Float_t* ubuf, Int_t nbuf) override;
+  void Medium(Int_t& kmed, const char* name, Int_t nmat, Int_t isvol, Int_t ifield, Double_t fieldm, Double_t tmaxfd, Double_t stemax, Double_t deemax, Double_t epsil, Double_t stmin, Float_t* ubuf, Int_t nbuf) override;
 
   /// The same as previous but in double precision
-  virtual void Medium(Int_t& kmed, const char* name, Int_t nmat, Int_t isvol, Int_t ifield, Double_t fieldm, Double_t tmaxfd, Double_t stemax, Double_t deemax, Double_t epsil, Double_t stmin, Double_t* ubuf, Int_t nbuf) override;
+  void Medium(Int_t& kmed, const char* name, Int_t nmat, Int_t isvol, Int_t ifield, Double_t fieldm, Double_t tmaxfd, Double_t stemax, Double_t deemax, Double_t epsil, Double_t stmin, Double_t* ubuf, Int_t nbuf) override;
 
   /// Define a rotation matrix
   /// - krot     rotation matrix number assigned
@@ -137,7 +137,7 @@ class MCReplayEngine : public TVirtualMC
   /// - phiY     azimuthal angle for axis Y
   /// - thetaZ   polar angle for axis Z
   /// - phiZ     azimuthal angle for axis Z
-  virtual void Matrix(Int_t& krot, Double_t thetaX, Double_t phiX, Double_t thetaY, Double_t phiY, Double_t thetaZ, Double_t phiZ) override;
+  void Matrix(Int_t& krot, Double_t thetaX, Double_t phiX, Double_t thetaY, Double_t phiY, Double_t thetaZ, Double_t phiZ) override;
 
   /// Change the value of cut or mechanism param
   /// to a new value parval for tracking medium itmed.
@@ -149,7 +149,7 @@ class MCReplayEngine : public TVirtualMC
   /// - itmed   tracking medium number
   /// - param   is a character string (variable name)
   /// - parval  must be given as a floating point.
-  virtual void Gstpar(Int_t itmed, const char* param, Double_t parval) override;
+  void Gstpar(Int_t itmed, const char* param, Double_t parval) override;
 
   //
   // functions from GGEOM
@@ -162,10 +162,10 @@ class MCReplayEngine : public TVirtualMC
   /// - nmed   Tracking medium number
   /// - np     Number of shape parameters
   /// - upar   Vector containing shape parameters
-  virtual Int_t Gsvolu(const char* name, const char* shape, Int_t nmed, Float_t* upar, Int_t np) override;
+  Int_t Gsvolu(const char* name, const char* shape, Int_t nmed, Float_t* upar, Int_t np) override;
 
   /// The same as previous but in double precision
-  virtual Int_t Gsvolu(const char* name, const char* shape, Int_t nmed, Double_t* upar, Int_t np) override;
+  Int_t Gsvolu(const char* name, const char* shape, Int_t nmed, Double_t* upar, Int_t np) override;
 
   /// Create a new volume by dividing an existing one.
   /// It divides a previously defined volume
@@ -174,13 +174,13 @@ class MCReplayEngine : public TVirtualMC
   /// - ndiv   Number of divisions
   /// - iaxis  Axis value:
   ///               X,Y,Z of CAXIS will be translated to 1,2,3 for IAXIS.
-  virtual void Gsdvn(const char* name, const char* mother, Int_t ndiv, Int_t iaxis) override;
+  void Gsdvn(const char* name, const char* mother, Int_t ndiv, Int_t iaxis) override;
 
   /// Create a new volume by dividing an existing one.
   /// Divide mother into ndiv divisions called name
   /// along axis iaxis starting at coordinate value c0i.
   /// The new volume created will be medium number numed.
-  virtual void Gsdvn2(const char* name, const char* mother, Int_t ndiv, Int_t iaxis, Double_t c0i, Int_t numed) override;
+  void Gsdvn2(const char* name, const char* mother, Int_t ndiv, Int_t iaxis, Double_t c0i, Int_t numed) override;
 
   /// Create a new volume by dividing an existing one
   /// Divide mother into divisions called name along
@@ -190,7 +190,7 @@ class MCReplayEngine : public TVirtualMC
   /// number numed. If numed is 0, numed of mother is taken.
   /// ndvmx is the expected maximum number of divisions
   /// (If 0, no protection tests are performed in Geant3)
-  virtual void Gsdvt(const char* name, const char* mother, Double_t step, Int_t iaxis, Int_t numed, Int_t ndvmx) override;
+  void Gsdvt(const char* name, const char* mother, Double_t step, Int_t iaxis, Int_t numed, Int_t ndvmx) override;
 
   /// Create a new volume by dividing an existing one
   /// Divides mother into divisions called name along
@@ -200,12 +200,12 @@ class MCReplayEngine : public TVirtualMC
   /// If numed is 0, numed of mother is taken.
   /// ndvmx is the expected maximum number of divisions
   /// (If 0, no protection tests are performed in Geant3)
-  virtual void Gsdvt2(const char* name, const char* mother, Double_t step, Int_t iaxis, Double_t c0, Int_t numed, Int_t ndvmx) override;
+  void Gsdvt2(const char* name, const char* mother, Double_t step, Int_t iaxis, Double_t c0, Int_t numed, Int_t ndvmx) override;
 
   /// Flag volume name whose contents will have to be ordered
   /// along axis iax, by setting the search flag to -iax
   /// (Geant3 only)
-  virtual void Gsord(const char* name, Int_t iax) override
+  void Gsord(const char* name, Int_t iax) override
   {
     Warning("Gsord", "Not supported");
   }
@@ -220,20 +220,20 @@ class MCReplayEngine : public TVirtualMC
   /// - z      Z coord. of the volume in mother ref. sys.
   /// - irot   Rotation matrix number w.r.t. mother ref. sys.
   /// - konly  ONLY/MANY flag
-  virtual void Gspos(const char* name, Int_t nr, const char* mother, Double_t x, Double_t y, Double_t z, Int_t irot, const char* konly = "ONLY") override;
+  void Gspos(const char* name, Int_t nr, const char* mother, Double_t x, Double_t y, Double_t z, Int_t irot, const char* konly = "ONLY") override;
 
   /// Place a copy of generic volume name with user number
   ///  nr inside mother, with its parameters upar(1..np)
-  virtual void Gsposp(const char* name, Int_t nr, const char* mother, Double_t x, Double_t y, Double_t z, Int_t irot, const char* konly, Float_t* upar, Int_t np) override;
+  void Gsposp(const char* name, Int_t nr, const char* mother, Double_t x, Double_t y, Double_t z, Int_t irot, const char* konly, Float_t* upar, Int_t np) override;
 
   /// The same as previous but in double precision
-  virtual void Gsposp(const char* name, Int_t nr, const char* mother, Double_t x, Double_t y, Double_t z, Int_t irot, const char* konly, Double_t* upar, Int_t np) override;
+  void Gsposp(const char* name, Int_t nr, const char* mother, Double_t x, Double_t y, Double_t z, Int_t irot, const char* konly, Double_t* upar, Int_t np) override;
 
   /// Helper function for resolving MANY.
   /// Specify the ONLY volume that overlaps with the
   /// specified MANY and has to be substracted.
   /// (Geant4 only)
-  virtual void Gsbool(const char* onlyVolName, const char* manyVolName) override
+  void Gsbool(const char* onlyVolName, const char* manyVolName) override
   {
     Warning("Gsbool", "Not supported");
   }
@@ -249,13 +249,13 @@ class MCReplayEngine : public TVirtualMC
   ///                     - metals    : absorption fraction (0<=x<=1)
   /// - effic       Detection efficiency for UV photons
   /// - rindex      Refraction index (if=0 metal)
-  virtual void SetCerenkov(Int_t itmed, Int_t npckov, Float_t* ppckov, Float_t* absco, Float_t* effic, Float_t* rindex, Bool_t aspline = false, Bool_t rspline = false) override
+  void SetCerenkov(Int_t itmed, Int_t npckov, Float_t* ppckov, Float_t* absco, Float_t* effic, Float_t* rindex, Bool_t aspline = false, Bool_t rspline = false) override
   {
     Warning("SetCerenkov", "Not supported");
   }
 
   /// The same as previous but in double precision
-  virtual void SetCerenkov(Int_t itmed, Int_t npckov, Double_t* ppckov, Double_t* absco, Double_t* effic, Double_t* rindex, Bool_t aspline = false, Bool_t rspline = false) override
+  void SetCerenkov(Int_t itmed, Int_t npckov, Double_t* ppckov, Double_t* absco, Double_t* effic, Double_t* rindex, Bool_t aspline = false, Bool_t rspline = false) override
   {
     Warning("SetCerenkov", "Not supported");
   }
@@ -273,7 +273,7 @@ class MCReplayEngine : public TVirtualMC
   /// - surfaceFinish  surface quality (see #EMCOpSurfaceType values)
   /// - sigmaAlpha     an unified model surface parameter
   /// (Geant4 only)
-  virtual void DefineOpSurface(const char* name, EMCOpSurfaceModel model, EMCOpSurfaceType surfaceType, EMCOpSurfaceFinish surfaceFinish, Double_t sigmaAlpha) override
+  void DefineOpSurface(const char* name, EMCOpSurfaceModel model, EMCOpSurfaceType surfaceType, EMCOpSurfaceFinish surfaceFinish, Double_t sigmaAlpha) override
   {
     Warning("DefineOpSurface", "Not supported");
   }
@@ -286,7 +286,7 @@ class MCReplayEngine : public TVirtualMC
   /// - vol2CopyNo  second volume copy number
   /// - opSurfaceName  name of optical surface which this border belongs to
   /// (Geant4 only)
-  virtual void SetBorderSurface(const char* name, const char* vol1Name, int vol1CopyNo, const char* vol2Name, int vol2CopyNo, const char* opSurfaceName) override
+  void SetBorderSurface(const char* name, const char* vol1Name, int vol1CopyNo, const char* vol2Name, int vol2CopyNo, const char* opSurfaceName) override
   {
     Warning("SetBorderSurface", "Not supported");
   }
@@ -296,7 +296,7 @@ class MCReplayEngine : public TVirtualMC
   /// - volName     volume name
   /// - opSurfaceName  name of optical surface which this border belongs to
   /// (Geant4 only)
-  virtual void SetSkinSurface(const char* name, const char* volName, const char* opSurfaceName) override
+  void SetSkinSurface(const char* name, const char* volName, const char* opSurfaceName) override
   {
     Warning("SetSkinSurface", "Not supported");
   }
@@ -308,7 +308,7 @@ class MCReplayEngine : public TVirtualMC
   /// - pp            value of photon momentum (in GeV)
   /// - values        property values
   /// (Geant4 only)
-  virtual void SetMaterialProperty(Int_t itmed, const char* propertyName, Int_t np, Double_t* pp, Double_t* values, Bool_t createNewKey = false, Bool_t spline = false) override
+  void SetMaterialProperty(Int_t itmed, const char* propertyName, Int_t np, Double_t* pp, Double_t* values, Bool_t createNewKey = false, Bool_t spline = false) override
   {
     Warning("SetMaterialProperty", "Not supported");
   }
@@ -318,7 +318,7 @@ class MCReplayEngine : public TVirtualMC
   /// - propertyName  property name
   /// - value         property value
   /// (Geant4 only)
-  virtual void SetMaterialProperty(Int_t itmed, const char* propertyName, Double_t value) override
+  void SetMaterialProperty(Int_t itmed, const char* propertyName, Double_t value) override
   {
     Warning("SetMaterialProperty", "Not supported");
   }
@@ -330,7 +330,7 @@ class MCReplayEngine : public TVirtualMC
   /// - pp            value of photon momentum (in GeV)
   /// - values        property values
   /// (Geant4 only)
-  virtual void SetMaterialProperty(const char* surfaceName, const char* propertyName, Int_t np, Double_t* pp, Double_t* values, Bool_t createNewKey = false, Bool_t spline = false) override
+  void SetMaterialProperty(const char* surfaceName, const char* propertyName, Int_t np, Double_t* pp, Double_t* values, Bool_t createNewKey = false, Bool_t spline = false) override
   {
     Warning("SetMaterialProperty", "Not supported");
   }
@@ -342,15 +342,15 @@ class MCReplayEngine : public TVirtualMC
 
   /// Return the transformation matrix between the volume specified by
   /// the path volumePath and the top or master volume.
-  virtual Bool_t GetTransformation(const TString& volumePath, TGeoHMatrix& matrix) override;
+  Bool_t GetTransformation(const TString& volumePath, TGeoHMatrix& matrix) override;
 
   /// Return the name of the shape (shapeType)  and its parameters par
   /// for the volume specified by the path volumePath .
-  virtual Bool_t GetShape(const TString& volumePath, TString& shapeType, TArrayD& par) override;
+  Bool_t GetShape(const TString& volumePath, TString& shapeType, TArrayD& par) override;
 
   /// Return the material parameters for the material specified by
   /// the material Id
-  virtual Bool_t GetMaterial(Int_t imat, TString& name, Double_t& a, Double_t& z, Double_t& density, Double_t& radl, Double_t& inter, TArrayD& par) override
+  Bool_t GetMaterial(Int_t imat, TString& name, Double_t& a, Double_t& z, Double_t& density, Double_t& radl, Double_t& inter, TArrayD& par) override
   {
     Warning("GetMaterial", "Not yet implemented");
     return kFALSE;
@@ -358,11 +358,11 @@ class MCReplayEngine : public TVirtualMC
 
   /// Return the material parameters for the volume specified by
   /// the volumeName.
-  virtual Bool_t GetMaterial(const TString& volumeName, TString& name, Int_t& imat, Double_t& a, Double_t& z, Double_t& density, Double_t& radl, Double_t& inter, TArrayD& par) override;
+  Bool_t GetMaterial(const TString& volumeName, TString& name, Int_t& imat, Double_t& a, Double_t& z, Double_t& density, Double_t& radl, Double_t& inter, TArrayD& par) override;
 
   /// Return the medium parameters for the volume specified by the
   /// volumeName.
-  virtual Bool_t GetMedium(const TString& volumeName, TString& name, Int_t& imed, Int_t& nmat, Int_t& isvol, Int_t& ifield, Double_t& fieldm, Double_t& tmaxfd, Double_t& stemax, Double_t& deemax, Double_t& epsil, Double_t& stmin, TArrayD& par) override;
+  Bool_t GetMedium(const TString& volumeName, TString& name, Int_t& imed, Int_t& nmat, Int_t& isvol, Int_t& ifield, Double_t& fieldm, Double_t& tmaxfd, Double_t& stemax, Double_t& deemax, Double_t& epsil, Double_t& stmin, TArrayD& par) override;
 
   /// Write out the geometry of the detector in EUCLID file format
   /// - filnam  file name - will be with the extension .euc                 *
@@ -372,19 +372,19 @@ class MCReplayEngine : public TVirtualMC
   ///                to be written out, starting from topvol
   /// (Geant3 only)
   /// Deprecated
-  virtual void WriteEuclid(const char* filnam, const char* topvol, Int_t number, Int_t nlevel) override
+  void WriteEuclid(const char* filnam, const char* topvol, Int_t number, Int_t nlevel) override
   {
     Warning("WriteEuclid", "Not supported");
   }
 
   /// Set geometry from Root (built via TGeo)
-  virtual void SetRootGeometry() override {}
+  void SetRootGeometry() override {}
 
   /// Activate the parameters defined in tracking media
   /// (DEEMAX, STMIN, STEMAX), which are, be default, ignored.
   /// In Geant4 case, only STEMAX is taken into account.
   /// In FLUKA, all tracking media parameters are ignored.
-  virtual void SetUserParameters(Bool_t isUserParameters) override
+  void SetUserParameters(Bool_t isUserParameters) override
   {
     Warning("SetUserParameters", "Not supported");
   }
@@ -395,28 +395,28 @@ class MCReplayEngine : public TVirtualMC
   //
 
   /// Return the unique numeric identifier for volume name volName
-  virtual Int_t VolId(const char* volName) const override;
+  Int_t VolId(const char* volName) const override;
 
   /// Return the volume name for a given volume identifier id
-  virtual const char* VolName(Int_t id) const override;
+  const char* VolName(Int_t id) const override;
 
   /// Return the unique numeric identifier for medium name mediumName
-  virtual Int_t MediumId(const char* mediumName) const override;
+  Int_t MediumId(const char* mediumName) const override;
 
   /// Return total number of volumes in the geometry
-  virtual Int_t NofVolumes() const override;
+  Int_t NofVolumes() const override;
 
   /// Return material number for a given volume id
-  virtual Int_t VolId2Mate(Int_t id) const override;
+  Int_t VolId2Mate(Int_t id) const override;
 
   /// Return number of daughters of the volume specified by volName
-  virtual Int_t NofVolDaughters(const char* volName) const override;
+  Int_t NofVolDaughters(const char* volName) const override;
 
   /// Return the name of i-th daughter of the volume specified by volName
-  virtual const char* VolDaughterName(const char* volName, Int_t i) const override;
+  const char* VolDaughterName(const char* volName, Int_t i) const override;
 
   /// Return the copyNo of i-th daughter of the volume specified by volName
-  virtual Int_t VolDaughterCopyNo(const char* volName, Int_t i) const override;
+  Int_t VolDaughterCopyNo(const char* volName, Int_t i) const override;
 
   //
   // ------------------------------------------------
@@ -427,14 +427,14 @@ class MCReplayEngine : public TVirtualMC
   // Set a sensitive detector to a volume
   // - volName - the volume name
   // - sd - the user sensitive detector
-  virtual void SetSensitiveDetector(const TString& volName, TVirtualMCSensitiveDetector* sd) override
+  void SetSensitiveDetector(const TString& volName, TVirtualMCSensitiveDetector* sd) override
   {
     Warning("SetSensitiveDetector", "Not supported");
   }
 
   // Get a sensitive detector of a volume
   // - volName - the volume name
-  virtual TVirtualMCSensitiveDetector* GetSensitiveDetector(const TString& volName) const override
+  TVirtualMCSensitiveDetector* GetSensitiveDetector(const TString& volName) const override
   {
     Warning("GetSensitiveDetector", "Not supported");
     return nullptr;
@@ -443,7 +443,7 @@ class MCReplayEngine : public TVirtualMC
   // The scoring option:
   // if true, scoring is performed only via user defined sensitive detectors and
   // MCApplication::Stepping is not called
-  virtual void SetExclusiveSDScoring(Bool_t exclusiveSDScoring) override
+  void SetExclusiveSDScoring(Bool_t exclusiveSDScoring) override
   {
     Warning("SetExclusiveSDScoring", "Not supported");
   }
@@ -460,10 +460,10 @@ class MCReplayEngine : public TVirtualMC
   //
 
   /// Set transport cuts for particles
-  virtual Bool_t SetCut(const char* cutName, Double_t cutValue) override;
+  Bool_t SetCut(const char* cutName, Double_t cutValue) override;
 
   /// Set process control
-  virtual Bool_t SetProcess(const char* flagName, Int_t flagValue) override;
+  Bool_t SetProcess(const char* flagName, Int_t flagValue) override;
 
   /// Set a user defined particle
   /// Function is ignored if particle with specified pdg
@@ -490,7 +490,7 @@ class MCReplayEngine : public TVirtualMC
   /// - antiEncoding  anti encoding
   /// - magMoment     magnetic moment
   /// - excitation    excitation energy [GeV]
-  virtual Bool_t DefineParticle(Int_t pdg, const char* name, TMCParticleType mcType, Double_t mass, Double_t charge, Double_t lifetime) override
+  Bool_t DefineParticle(Int_t pdg, const char* name, TMCParticleType mcType, Double_t mass, Double_t charge, Double_t lifetime) override
   {
     Warning("DefineParticle", "Not yet implemented");
     return kFALSE;
@@ -521,11 +521,11 @@ class MCReplayEngine : public TVirtualMC
   /// - antiEncoding  anti encoding
   /// - magMoment     magnetic moment
   /// - excitation    excitation energy [GeV]
-  virtual Bool_t DefineParticle(Int_t pdg, const char* name, TMCParticleType mcType, Double_t mass, Double_t charge, Double_t lifetime,
-                                const TString& pType, Double_t width, Int_t iSpin, Int_t iParity, Int_t iConjugation,
-                                Int_t iIsospin, Int_t iIsospinZ, Int_t gParity, Int_t lepton, Int_t baryon, Bool_t stable,
-                                Bool_t shortlived = kFALSE, const TString& subType = "", Int_t antiEncoding = 0, Double_t magMoment = 0.0,
-                                Double_t excitation = 0.0) override
+  Bool_t DefineParticle(Int_t pdg, const char* name, TMCParticleType mcType, Double_t mass, Double_t charge, Double_t lifetime,
+                        const TString& pType, Double_t width, Int_t iSpin, Int_t iParity, Int_t iConjugation,
+                        Int_t iIsospin, Int_t iIsospinZ, Int_t gParity, Int_t lepton, Int_t baryon, Bool_t stable,
+                        Bool_t shortlived = kFALSE, const TString& subType = "", Int_t antiEncoding = 0, Double_t magMoment = 0.0,
+                        Double_t excitation = 0.0) override
   {
     Warning("DefineParticle", "Not yet implemented");
     return kFALSE;
@@ -539,7 +539,7 @@ class MCReplayEngine : public TVirtualMC
   /// - excitation    excitation energy [GeV]
   /// - mass          mass  [GeV] (if not specified by user, approximative
   ///                 mass is calculated)
-  virtual Bool_t DefineIon(const char* name, Int_t Z, Int_t A, Int_t Q, Double_t excEnergy, Double_t mass = 0.) override
+  Bool_t DefineIon(const char* name, Int_t Z, Int_t A, Int_t Q, Double_t excEnergy, Double_t mass = 0.) override
   {
     Warning("DefineIon", "Not yet implemented");
     return kFALSE;
@@ -550,7 +550,7 @@ class MCReplayEngine : public TVirtualMC
   /// -  bratios       the array with branching ratios (in %)
   /// -  mode[6][3]    the array with daughters particles PDG codes  for each
   ///                 decay channel
-  virtual Bool_t SetDecayMode(Int_t pdg, Float_t bratio[6], Int_t mode[6][3]) override
+  Bool_t SetDecayMode(Int_t pdg, Float_t bratio[6], Int_t mode[6][3]) override
   {
     Warning("SetDecayMode", "Not yet implemented");
     return kFALSE;
@@ -559,7 +559,7 @@ class MCReplayEngine : public TVirtualMC
   /// Calculate X-sections
   /// (Geant3 only)
   /// Deprecated
-  virtual Double_t Xsec(char*, Double_t, Int_t, Int_t) override
+  Double_t Xsec(char*, Double_t, Int_t, Int_t) override
   {
     Warning("Xsec", "Not yet implemented");
     return -1.;
@@ -571,14 +571,14 @@ class MCReplayEngine : public TVirtualMC
   //
 
   /// Return MC specific code from a PDG and pseudo ENDF code (pdg)
-  virtual Int_t IdFromPDG(Int_t pdg) const override
+  Int_t IdFromPDG(Int_t pdg) const override
   {
     Warning("IdFromPDG", "Not yet implemented");
     return -1;
   }
 
   /// Return PDG code and pseudo ENDF code from MC specific code (id)
-  virtual Int_t PDGFromId(Int_t id) const override
+  Int_t PDGFromId(Int_t id) const override
   {
     Warning("PDGFromId", "Not yet implemented");
     return -1;
@@ -590,35 +590,35 @@ class MCReplayEngine : public TVirtualMC
   //
 
   /// Return name of the particle specified by pdg.
-  virtual TString ParticleName(Int_t pdg) const override
+  TString ParticleName(Int_t pdg) const override
   {
     Warning("ParticleName", "Not yet implemented");
     return TString();
   }
 
   /// Return mass of the particle specified by pdg.
-  virtual Double_t ParticleMass(Int_t pdg) const override
+  Double_t ParticleMass(Int_t pdg) const override
   {
     Warning("ParticleMass", "Not yet implemented");
     return -1.;
   }
 
   /// Return charge (in e units) of the particle specified by pdg.
-  virtual Double_t ParticleCharge(Int_t pdg) const override
+  Double_t ParticleCharge(Int_t pdg) const override
   {
     Warning("ParticleCharge", "Not yet implemented");
     return -1.;
   }
 
   /// Return life time of the particle specified by pdg.
-  virtual Double_t ParticleLifeTime(Int_t pdg) const override
+  Double_t ParticleLifeTime(Int_t pdg) const override
   {
     Warning("ParticleLifeTime", "Not yet implemented");
     return -1.;
   }
 
   /// Return VMC type of the particle specified by pdg.
-  virtual TMCParticleType ParticleMCType(Int_t pdg) const override
+  TMCParticleType ParticleMCType(Int_t pdg) const override
   {
     Warning("ParticleMCType", "Not yet implemented");
     return TMCParticleType();
@@ -635,21 +635,21 @@ class MCReplayEngine : public TVirtualMC
   //
 
   /// Stop the transport of the current particle and skip to the next
-  virtual void StopTrack() override
+  void StopTrack() override
   {
     // Actually, that should never be called but can happen in a replay due to double (original) vs. float (replay), or similar
     mIsTrackStopped = true;
   }
 
   /// Stop simulation of the current event and skip to the next
-  virtual void StopEvent() override
+  void StopEvent() override
   {
     StopTrack();
     mIsEventStopped = true;
   }
 
   /// Stop simulation of the current event and set the abort run flag to true
-  virtual void StopRun() override
+  void StopRun() override
   {
     StopEvent();
     mIsRunStopped = true;
@@ -661,26 +661,26 @@ class MCReplayEngine : public TVirtualMC
   //
 
   /// Set the maximum step allowed till the particle is in the current medium
-  virtual void SetMaxStep(Double_t) override
+  void SetMaxStep(Double_t) override
   {
     // Warning("SetMaxStep", "Not yet implemented");
   }
 
   /// Set the maximum number of steps till the particle is in the current medium
-  virtual void SetMaxNStep(Int_t) override
+  void SetMaxNStep(Int_t) override
   {
     Warning("SetMaxNStep", "Not yet implemented");
   }
 
   /// Force the decays of particles to be done with Pythia
   /// and not with the Geant routines.
-  virtual void SetUserDecay(Int_t pdg) override
+  void SetUserDecay(Int_t pdg) override
   {
     Warning("SetUserDecay", "Not yet implemented");
   }
 
   /// Force the decay time of the current particle
-  virtual void ForceDecayTime(Float_t) override
+  void ForceDecayTime(Float_t) override
   {
     Warning("ForceDecayTime", "Not yet implemented");
   }
@@ -691,26 +691,26 @@ class MCReplayEngine : public TVirtualMC
   //
 
   /// Return the current volume ID and copy number
-  virtual Int_t CurrentVolID(Int_t& copyNo) const override;
+  Int_t CurrentVolID(Int_t& copyNo) const override;
 
   /// Return the current volume off upward in the geometrical tree
   /// ID and copy number
-  virtual Int_t CurrentVolOffID(Int_t off, Int_t& copyNo) const override;
+  Int_t CurrentVolOffID(Int_t off, Int_t& copyNo) const override;
 
   /// Return the current volume name
-  virtual const char* CurrentVolName() const override;
+  const char* CurrentVolName() const override;
 
   /// Return the current volume off upward in the geometrical tree
   /// name and copy number'
   /// if name=0 no name is returned
-  virtual const char* CurrentVolOffName(Int_t off) const override;
+  const char* CurrentVolOffName(Int_t off) const override;
 
   /// Return the path in geometry tree for the current volume
-  virtual const char* CurrentVolPath() override;
+  const char* CurrentVolPath() override;
 
   /// If track is on a geometry boundary, fill the normal vector of the crossing
   /// volume surface and return true, return false otherwise
-  virtual Bool_t CurrentBoundaryNormal(Double_t& x, Double_t& y, Double_t& z) const override
+  Bool_t CurrentBoundaryNormal(Double_t& x, Double_t& y, Double_t& z) const override
   {
     // TODO Not yet implemented, needs some investigation how it is implemente din TGeant3 or TGeant4
     Warning("CurrentBoundaryNormal", "Not yet implemented");
@@ -718,21 +718,21 @@ class MCReplayEngine : public TVirtualMC
   }
 
   /// Return the parameters of the current material during transport
-  virtual Int_t CurrentMaterial(Float_t& a, Float_t& z, Float_t& dens, Float_t& radl, Float_t& absl) const override
+  Int_t CurrentMaterial(Float_t& a, Float_t& z, Float_t& dens, Float_t& radl, Float_t& absl) const override
   {
     Warning("CurrentMaterial", "Not yet implemented");
     return -1;
   }
 
   //// Return the number of the current medium
-  virtual Int_t CurrentMedium() const override
+  Int_t CurrentMedium() const override
   {
     return getMediumId(mCurrentStep->volId);
   }
   // new function (to replace GetMedium() const)
 
   /// Return the number of the current event
-  virtual Int_t CurrentEvent() const override
+  Int_t CurrentEvent() const override
   {
     return mCurrentEvent;
   }
@@ -744,10 +744,10 @@ class MCReplayEngine : public TVirtualMC
   /// - iflag
   ///   - IFLAG = 1  convert coordinates
   ///   - IFLAG = 2  convert direction cosines
-  virtual void Gmtod(Float_t* xm, Float_t* xd, Int_t iflag) override;
+  void Gmtod(Float_t* xm, Float_t* xd, Int_t iflag) override;
 
   /// The same as previous but in double precision
-  virtual void Gmtod(Double_t* xm, Double_t* xd, Int_t iflag) override;
+  void Gmtod(Double_t* xm, Double_t* xd, Int_t iflag) override;
 
   /// Computes coordinates xm in mother reference system
   /// from known coordinates xd in daughter reference system.
@@ -756,19 +756,19 @@ class MCReplayEngine : public TVirtualMC
   /// - iflag
   ///   - IFLAG = 1  convert coordinates
   ///   - IFLAG = 2  convert direction cosines
-  virtual void Gdtom(Float_t* xd, Float_t* xm, Int_t iflag) override;
+  void Gdtom(Float_t* xd, Float_t* xm, Int_t iflag) override;
 
   /// The same as previous but in double precision
-  virtual void Gdtom(Double_t* xd, Double_t* xm, Int_t iflag) override;
+  void Gdtom(Double_t* xd, Double_t* xm, Int_t iflag) override;
 
   /// Return the maximum step length in the current medium
-  virtual Double_t MaxStep() const override
+  Double_t MaxStep() const override
   {
     return mCurrentStep->maxstep;
   }
 
   /// Return the maximum number of steps allowed in the current medium
-  virtual Int_t GetMaxNStep() const override
+  Int_t GetMaxNStep() const override
   {
     Warning("MaxStep", "Not yet implemented");
     return -1.;
@@ -783,14 +783,14 @@ class MCReplayEngine : public TVirtualMC
 
   /// Return the current position in the master reference frame of the
   /// track being transported
-  virtual void TrackPosition(TLorentzVector& position) const override
+  void TrackPosition(TLorentzVector& position) const override
   {
     // Time not yet implemented in MCStepLogger
     position.SetXYZT(mCurrentStep->x, mCurrentStep->y, mCurrentStep->z, mCurrentStep->t);
   }
 
   /// Only return spatial coordinates (as double)
-  virtual void TrackPosition(Double_t& x, Double_t& y, Double_t& z) const override
+  void TrackPosition(Double_t& x, Double_t& y, Double_t& z) const override
   {
     x = mCurrentStep->x;
     y = mCurrentStep->y;
@@ -798,7 +798,7 @@ class MCReplayEngine : public TVirtualMC
   }
 
   /// Only return spatial coordinates (as float)
-  virtual void TrackPosition(Float_t& x, Float_t& y, Float_t& z) const override
+  void TrackPosition(Float_t& x, Float_t& y, Float_t& z) const override
   {
     x = mCurrentStep->x;
     y = mCurrentStep->y;
@@ -807,14 +807,14 @@ class MCReplayEngine : public TVirtualMC
 
   /// Return the direction and the momentum (GeV/c) of the track
   /// currently being transported
-  virtual void TrackMomentum(TLorentzVector& momentum) const override
+  void TrackMomentum(TLorentzVector& momentum) const override
   {
     momentum.SetXYZT(mCurrentStep->px, mCurrentStep->py, mCurrentStep->pz, mCurrentStep->E);
   }
 
   /// Return the direction and the momentum (GeV/c) of the track
   /// currently being transported (as double)
-  virtual void TrackMomentum(Double_t& px, Double_t& py, Double_t& pz, Double_t& etot) const override
+  void TrackMomentum(Double_t& px, Double_t& py, Double_t& pz, Double_t& etot) const override
   {
     px = mCurrentStep->px;
     py = mCurrentStep->py;
@@ -824,7 +824,7 @@ class MCReplayEngine : public TVirtualMC
 
   /// Return the direction and the momentum (GeV/c) of the track
   /// currently being transported (as float)
-  virtual void TrackMomentum(Float_t& px, Float_t& py, Float_t& pz, Float_t& etot) const override
+  void TrackMomentum(Float_t& px, Float_t& py, Float_t& pz, Float_t& etot) const override
   {
     px = mCurrentStep->px;
     py = mCurrentStep->py;
@@ -833,32 +833,32 @@ class MCReplayEngine : public TVirtualMC
   }
 
   /// Return the length in centimeters of the current step (in cm)
-  virtual Double_t TrackStep() const override
+  Double_t TrackStep() const override
   {
     return mCurrentStep->step;
   }
 
   /// Return the length of the current track from its origin (in cm)
-  virtual Double_t TrackLength() const override
+  Double_t TrackLength() const override
   {
     return mCurrentTrackLength;
   }
 
   /// Return the current time of flight of the track being transported
-  virtual Double_t TrackTime() const override
+  Double_t TrackTime() const override
   {
     return mCurrentStep->t;
   }
 
   /// Return the energy lost in the current step
-  virtual Double_t Edep() const override
+  Double_t Edep() const override
   {
     return mCurrentStep->edep;
   }
 
   /// Return the non-ionising energy lost (NIEL) in the current step
   // TODO To be implemented???
-  virtual Double_t NIELEdep() const override
+  Double_t NIELEdep() const override
   {
     Warning("NIELEdep", "Not yet implemented");
     return -1.;
@@ -866,7 +866,7 @@ class MCReplayEngine : public TVirtualMC
 
   /// Return the current step number
   // TODO To be implemented
-  virtual Int_t StepNumber() const override
+  Int_t StepNumber() const override
   {
     Warning("StepNumber", "Not yet implemented");
     return -1;
@@ -874,7 +874,7 @@ class MCReplayEngine : public TVirtualMC
 
   /// Get the current weight
   // TODO To be implemented
-  virtual Double_t TrackWeight() const override
+  Double_t TrackWeight() const override
   {
     Warning("TrackWeight", "Not yet implemented");
     return -1.;
@@ -882,14 +882,14 @@ class MCReplayEngine : public TVirtualMC
 
   /// Get the current polarization
   // TODO To be implemented
-  virtual void TrackPolarization(Double_t& polX, Double_t& polY, Double_t& polZ) const override
+  void TrackPolarization(Double_t& polX, Double_t& polY, Double_t& polZ) const override
   {
     Warning("TrackPolarization", "Not yet implemented");
   }
 
   /// Get the current polarization
   // TODO To be implemented
-  virtual void TrackPolarization(TVector3& pol) const override
+  void TrackPolarization(TVector3& pol) const override
   {
     Warning("TrackPolarization", "Not yet implemented");
   }
@@ -902,25 +902,25 @@ class MCReplayEngine : public TVirtualMC
   //
 
   /// Return the PDG of the particle transported
-  virtual Int_t TrackPid() const override
+  Int_t TrackPid() const override
   {
     return mCurrentLookups->tracktopdg[mCurrentStep->trackID];
   }
 
   /// Return the charge of the track currently transported
-  virtual Double_t TrackCharge() const override
+  Double_t TrackCharge() const override
   {
     return mCurrentLookups->tracktocharge[mCurrentStep->trackID];
   }
 
   /// Return the mass of the track currently transported
-  virtual Double_t TrackMass() const override
+  Double_t TrackMass() const override
   {
     return mCurrentLookups->tracktomass[mCurrentStep->trackID];
   }
 
   /// Return the total energy of the current track
-  virtual Double_t Etot() const override
+  Double_t Etot() const override
   {
     // TODO make sure E is actually the energy and NOT the energy deposit
     return mCurrentStep->E;
@@ -932,31 +932,31 @@ class MCReplayEngine : public TVirtualMC
   //
 
   /// Return true when the track performs the first step
-  virtual Bool_t IsNewTrack() const override
+  Bool_t IsNewTrack() const override
   {
     return mCurrentStep->newtrack;
   }
 
   /// Return true if the track is not at the boundary of the current volume
-  virtual Bool_t IsTrackInside() const override
+  Bool_t IsTrackInside() const override
   {
     return mCurrentStep->inside;
   }
 
   /// Return true if this is the first step of the track in the current volume
-  virtual Bool_t IsTrackEntering() const override
+  Bool_t IsTrackEntering() const override
   {
     return mCurrentStep->entered;
   }
 
   /// Return true if this is the last step of the track in the current volume
-  virtual Bool_t IsTrackExiting() const override
+  Bool_t IsTrackExiting() const override
   {
     return mCurrentStep->exited;
   }
 
   /// Return true if the track is out of the setup
-  virtual Bool_t IsTrackOut() const override
+  Bool_t IsTrackOut() const override
   {
     return mCurrentStep->outside;
   }
@@ -964,20 +964,20 @@ class MCReplayEngine : public TVirtualMC
   /// Return true if the current particle has disappeared
   /// either because it decayed or because it underwent
   /// an inelastic collision
-  virtual Bool_t IsTrackDisappeared() const override
+  Bool_t IsTrackDisappeared() const override
   {
     return mCurrentStep->disappeared;
   }
 
   /// Return true if the track energy has fallen below the threshold
-  virtual Bool_t IsTrackStop() const override
+  Bool_t IsTrackStop() const override
   {
     return mCurrentStep->stopped;
   }
 
   /// Return true if the current particle is alive and will continue to be
   /// transported
-  virtual Bool_t IsTrackAlive() const override
+  Bool_t IsTrackAlive() const override
   {
     return !mCurrentStep->stopped;
   }
@@ -988,14 +988,14 @@ class MCReplayEngine : public TVirtualMC
   //
 
   /// Return the number of secondary particles generated in the current step
-  virtual Int_t NSecondaries() const override
+  Int_t NSecondaries() const override
   {
     return mCurrentStep->nsecondaries;
   }
 
   /// Return the parameters of the secondary track number isec produced
   /// in the current step
-  virtual void GetSecondary(Int_t isec, Int_t& particleId, TLorentzVector& position, TLorentzVector& momentum) override
+  void GetSecondary(Int_t isec, Int_t& particleId, TLorentzVector& position, TLorentzVector& momentum) override
   {
     // TODO Not possible atm with MCStepLogger, only secondary info is the number of secondaries produced
     Warning("GetSecondary", "Not yet implemented");
@@ -1003,7 +1003,7 @@ class MCReplayEngine : public TVirtualMC
 
   /// Return the VMC code of the process that has produced the secondary
   /// particles in the current step
-  virtual TMCProcess ProdProcess(Int_t isec) const override
+  TMCProcess ProdProcess(Int_t isec) const override
   {
     // TODO Not possible atm with MCStepLogger, only secondary info is the number of secondaries produced
     Warning("ProdProcess", "Not yet implemented");
@@ -1012,7 +1012,7 @@ class MCReplayEngine : public TVirtualMC
 
   /// Return the array of the VMC code of the processes active in the current
   /// step
-  virtual Int_t StepProcesses(TArrayI& proc) const override
+  Int_t StepProcesses(TArrayI& proc) const override
   {
     // TODO Not possible atm with MCStepLogger, donet have that info
     // Warning("StepProcesses", "Not yet implemented");
@@ -1020,7 +1020,7 @@ class MCReplayEngine : public TVirtualMC
   }
 
   /// Return the information about the transport order needed by the stack
-  virtual Bool_t SecondariesAreOrdered() const override
+  Bool_t SecondariesAreOrdered() const override
   {
     return kTRUE;
   }
@@ -1032,27 +1032,27 @@ class MCReplayEngine : public TVirtualMC
   //
 
   /// Initialize MC
-  virtual void Init() override;
+  void Init() override;
 
   /// Initialize MC physics
-  virtual void BuildPhysics() override
+  void BuildPhysics() override
   {
     Info("BuildPhysics", "Not implemented because not needed at the moment");
   }
 
   /// Process one event
   // TODO To be implemented
-  virtual void ProcessEvent(Int_t eventId) override;
+  void ProcessEvent(Int_t eventId) override;
 
   /// Process one event
   // TODO To be implemented
-  virtual void ProcessEvent(Int_t eventId, Bool_t isInterruptible) override
+  void ProcessEvent(Int_t eventId, Bool_t isInterruptible) override
   {
   }
 
   /// Process one event (backward-compatibility)
   // TODO To be implemented
-  virtual void ProcessEvent() override
+  void ProcessEvent() override
   {
     // Here we assume that the transport of the next event is desired
     ProcessEvent(mCurrentEvent);
@@ -1060,43 +1060,43 @@ class MCReplayEngine : public TVirtualMC
 
   /// That triggers stopping the transport of the current track without dispatching
   /// to common routines like TVirtualMCApplication::PostTrack() etc.
-  virtual void InterruptTrack()
+  void InterruptTrack() override
   {
     Info("InterruptTrack", "Not implemented");
   }
 
   /// Process one  run and return true if run has finished successfully,
   /// return false in other cases (run aborted by user)
-  virtual Bool_t ProcessRun(Int_t nevent) override;
+  Bool_t ProcessRun(Int_t nevent) override;
 
   /// Additional cleanup after a run can be done here (optional)
   // TODO To be implemented
-  virtual void TerminateRun() override
+  void TerminateRun() override
   {
     Warning("TerminateRun", "Nothing to be done yet");
   }
 
   /// Set switches for lego transport
-  virtual void InitLego() override
+  void InitLego() override
   {
     Warning("InitLego", "Not yet implemented");
   }
 
   /// (In)Activate collecting TGeo tracks
-  virtual void SetCollectTracks(Bool_t collectTracks) override
+  void SetCollectTracks(Bool_t collectTracks) override
   {
     Warning("SetCollectTracks", "Not yet implemented");
   }
 
   /// Return the info if collecting tracks is activated
-  virtual Bool_t IsCollectTracks() const override
+  Bool_t IsCollectTracks() const override
   {
     Warning("IsCollectTracks", "Not yet implemented");
     return kFALSE;
   }
 
   /// Return the info if multi-threading is supported/activated
-  virtual Bool_t IsMT() const override { return kFALSE; }
+  Bool_t IsMT() const override { return kFALSE; }
 
   // set filename and treename where to find the steps
   void setStepFilename(const std::string& filename)


### PR DESCRIPTION
MCStepLogger had compilation issues with conflicting C++ versions appearing on the command line. This is avoided by a CMakeList simplification.

Also fixing few compilation warnings related to inconsistent virtual + override.